### PR TITLE
feat(FE): 면접관 응답 확인 페이지 추가 (#87)

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -181,6 +181,14 @@ const routes = [
             component: () =>
                 import('@/views/interview/InterviewScheduleCreateView.vue'),
             meta: { requiresAuth: true }
+        },
+
+        {
+            path: 'recruitment/interview/response',
+            name: 'InterviewResponse',
+            component: () =>
+                import('@/views/interview/InterviewResponse.vue'),
+            meta: { requiresAuth: true }
         }
     ]
   },

--- a/src/views/MyScheduleView.vue
+++ b/src/views/MyScheduleView.vue
@@ -7,6 +7,7 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import { useRoute } from 'vue-router'
 import { useNotificationStore } from '@/Stores/notification'
 import { storeToRefs } from 'pinia'
+import { useRouter } from 'vue-router'
 
 // 1. 상태 및 상수 정의
 const currentView = ref('MONTH')
@@ -347,6 +348,14 @@ const confirmDelete = () => {
   isFormModalOpen.value = false
   targetDeleteId.value = null
 }
+
+// 면접관 응답 확인 연결
+const router = useRouter()
+
+const goToInterviewResponse = () => {
+  router.push('/recruitment/interview/response')
+}
+
 </script>
 
 <template>
@@ -567,9 +576,28 @@ const confirmDelete = () => {
               <p class="text-[11px] text-slate-500 mt-1.5 font-medium flex items-center gap-1.5"><svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>{{ event.time }}</p>
             </div>
           </div>
+          <!-- 면접관 응답 확인 버튼 영역 -->
+          <div class="mt-6 pt-5 border-t border-slate-200">
+            <button
+                @click="$router.push('/recruitment/interview/response')"
+                class="w-full flex items-center justify-center gap-2 py-3 rounded-xl
+           bg-brand-50 text-brand-600 font-bold text-sm
+           hover:bg-brand-100 transition-all"
+            >
+              면접관 응답 확인
+              <svg class="w-4 h-4 transition-transform group-hover:translate-x-1"
+                   fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
     </div>
+
+
 
     <ScheduleDetailModal
         :isOpen="isDetailModalOpen"

--- a/src/views/interview/InterviewResponse.vue
+++ b/src/views/interview/InterviewResponse.vue
@@ -1,0 +1,104 @@
+<script setup>
+import { ref } from 'vue'
+
+/* 임시 더미 데이터 */
+const interviews = ref([
+  {
+    id: 1,
+    title: '기술 면접 - 박지원',
+    date: '2026-02-17',
+    time: '13:00 ~ 14:30',
+    room: '회의실 A',
+    interviewers: [
+      { name: '김기술', status: 'ACCEPT' },
+      { name: '박상수', status: 'PENDING' },
+      { name: '이인사', status: 'REJECT' }
+    ]
+  },
+
+  {
+    id: 2,
+    title: '임원 면접',
+    date: '2026-02-18',
+    time: '15:00 ~ 16:00',
+    room: '회의실 B',
+    interviewers: [
+      { name: '최대표', status: 'ACCEPT' },
+      { name: '정임원', status: 'ACCEPT' },
+      { name: '김이사', status: 'PENDING' }
+    ]
+  }
+])
+
+const getStatusClass = (status) => {
+  if (status === 'ACCEPT') return 'text-blue-600'
+  if (status === 'REJECT') return 'text-red-500'
+  return 'text-slate-400'
+}
+
+const getStatusText = (status) => {
+  if (status === 'ACCEPT') return '수락'
+  if (status === 'REJECT') return '거절'
+  return '미응답'
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-slate-50 p-10 text-slate-900">
+
+    <div class="max-w-5xl mx-auto bg-white rounded-3xl shadow border p-8">
+
+      <h1 class="text-2xl font-extrabold mb-8 text-slate-900">
+        면접관 응답 현황
+      </h1>
+
+      <div class="space-y-6">
+
+        <div
+            v-for="item in interviews"
+            :key="item.id"
+            class="border rounded-2xl p-6 hover:shadow-md transition"
+        >
+
+          <!-- 상단 -->
+          <div class="flex justify-between mb-4">
+
+            <div>
+              <h3 class="font-bold text-lg text-slate-900">
+                {{ item.title }}
+              </h3>
+
+              <p class="text-sm text-slate-600 mt-1 font-medium">
+                {{ item.date }} · {{ item.time }} · {{ item.room }}
+              </p>
+            </div>
+
+          </div>
+
+          <!-- 면접관 응답 -->
+          <div class="flex flex-wrap gap-4">
+
+            <div
+                v-for="person in item.interviewers"
+                :key="person.name"
+                class="px-4 py-2 rounded-lg border text-sm font-bold flex items-center gap-2"
+            >
+              <span>{{ person.name }}</span>
+
+              <span
+                  :class="getStatusClass(person.status)"
+              >
+                {{ getStatusText(person.status) }}
+              </span>
+            </div>
+
+          </div>
+
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
+</template>


### PR DESCRIPTION
## 💡 개요
인사 담당자가 초대장을 보낸후 면접관들의 응바을 확인할 수 있는 페이지 구현

## 🔗 관련 이슈
Closes #87 

## 📝 작업 상세 내용
- [ ] 면접관 응답 상태 구현 

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 면접 응답 페이지 추가
  * 일정 보기에서 면접 응답 페이지로 이동할 수 있는 버튼 추가
  * 면접 일정과 면접관 상태 정보를 확인할 수 있는 화면 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->