### PR TITLE
fix : [FE] 지원서, 리포트, 팀관리 헤더 통일

### DIFF
--- a/src/views/ApplicantListView.vue
+++ b/src/views/ApplicantListView.vue
@@ -116,8 +116,6 @@ const exportToExcel = () => {
   <div class="space-y-6">
     <!-- 헤더 -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-      <h1 class="text-2xl font-bold text-gray-900">지원자 관리</h1>
-
       <!-- 필터 영역 -->
       <div class="flex flex-wrap items-center gap-3">
         <!-- 검색 -->
@@ -151,17 +149,18 @@ const exportToExcel = () => {
           <option v-for="status in statuses" :key="status" :value="status">{{ status }}</option>
         </select>
 
-        <!-- 엑셀 다운로드 버튼 -->
-        <button
-          @click="exportToExcel"
-          class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors"
-        >
-          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-          </svg>
-          엑셀 다운로드
-        </button>
       </div>
+
+      <!-- 엑셀 다운로드 버튼 -->
+      <button
+        @click="exportToExcel"
+        class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors sm:ml-auto"
+      >
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        엑셀 다운로드
+      </button>
     </div>
 
     <!-- 테이블 -->

--- a/src/views/ApplicationTemplateListView.vue
+++ b/src/views/ApplicationTemplateListView.vue
@@ -121,8 +121,6 @@ const handleDeleteCancel = () => {
   <div class="space-y-6">
     <!-- 헤더 -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-      <h1 class="text-2xl font-bold text-gray-900">지원서 템플릿</h1>
-
       <div class="flex items-center gap-3">
         <!-- 검색 -->
         <div class="relative">
@@ -137,17 +135,18 @@ const handleDeleteCancel = () => {
           </svg>
         </div>
 
-        <!-- 템플릿 생성 버튼 -->
-        <button
-          @click="goToCreate"
-          class="flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors font-medium"
-        >
-          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-          </svg>
-          템플릿 생성
-        </button>
       </div>
+
+      <!-- 템플릿 생성 버튼 -->
+      <button
+        @click="goToCreate"
+        class="flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors font-medium sm:ml-auto"
+      >
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        템플릿 생성
+      </button>
     </div>
 
     <!-- 테이블 -->

--- a/src/views/ReportView.vue
+++ b/src/views/ReportView.vue
@@ -147,8 +147,7 @@ const formatPercent = (v) => v + '%'
 
 <template>
   <div class="space-y-8">
-    <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-bold text-gray-900">리포트</h1>
+    <div class="flex items-center justify-end">
       <span class="text-sm text-gray-400">기준: 2026년 2월</span>
     </div>
 

--- a/src/views/TeamManagementView.vue
+++ b/src/views/TeamManagementView.vue
@@ -184,12 +184,8 @@ const getGroupColor = (groupName) => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-slate-50 p-8 font-sans text-slate-700">
-    <header class="flex justify-between items-end mb-12">
-      <div>
-        <h1 class="text-4xl font-display font-bold text-slate-900 tracking-tight">팀 관리</h1>
-        <p class="text-slate-500 mt-2 text-lg"> 사용자 정보와 활동 내역을 상세히 확인하세요.</p>
-      </div>
+  <div class="min-h-screen bg-slate-50 px-8 pt-2 pb-8 font-sans text-slate-700">
+    <header class="flex justify-end items-end mb-8">
       <div class="flex gap-3">
         <button @click="openGroupModal" class="px-5 py-3 bg-white hover:bg-slate-50 text-slate-600 border border-slate-200 rounded-xl transition-all shadow-sm font-medium">+ 그룹 추가</button>
         <button @click="openInviteModal" class="px-6 py-3 bg-teal-600 hover:bg-teal-500 text-white font-bold rounded-xl shadow-lg shadow-teal-600/20 transition-all">멤버 초대</button>


### PR DESCRIPTION
## 💡 개요
> 지원서, 리포트, 팀관리 헤더 스타일 통일

## 🔗 관련 이슈
Closes #105 

## 📝 작업 상세 내용
- [ ] 지원서, 리포트, 팀관리 헤더 통일
- [ ] 
- [ ] 

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 여러 페이지의 헤더 레이아웃을 개선하여 액션 버튼이 우측에 통일되도록 정렬했습니다.
  * 페이지 헤더의 제목 요소를 제거하여 UI를 간결하게 개선했습니다.
  * 전반적인 간격과 패딩을 조정하여 시각적 계층을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->