### PR TITLE
[FE] 지원서 템플릿 CRUD 및 스토어 연동 구현

### DIFF
--- a/src/Stores/recruitment.js
+++ b/src/Stores/recruitment.js
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-
 import recruitmentData from '@/data/recruitment.json'
 
 export const useRecruitmentStore = defineStore('recruitment', () => {
@@ -48,5 +47,46 @@ export const useRecruitmentStore = defineStore('recruitment', () => {
     }
   }
 
-  return { jobs, addJob, deleteJob, updateJob }
+  const templates = ref([
+    { id: 1, name: '백엔드 개발자 지원서', title: '백엔드 개발자 지원서', createdAt: '2024.01.15', updatedAt: '2024.01.20', status: '사용중', customFields: [{ id: 'intro', label: '자기소개', type: 'long_text', required: true }] },
+    { id: 2, name: '프론트엔드 개발자 지원서', title: '프론트엔드 개발자 지원서', createdAt: '2024.01.18', updatedAt: '2024.01.25', status: '사용중', customFields: [] },
+  ])
+
+  // 템플릿 생성 (생성 페이지에서 호출)
+  const addTemplate = (template) => {
+    const maxId = templates.value.length > 0 ? Math.max(...templates.value.map(t => t.id)) : 0
+    const today = new Date().toISOString().split('T')[0].replace(/-/g, '.') // YYYY.MM.DD 형식
+
+    templates.value.unshift({
+      id: maxId + 1,
+      name: template.title,
+      title: template.title,
+      status: '미사용',
+      createdAt: today,
+      updatedAt: '',
+      customFields: template.customFields || []
+    })
+  }
+
+  // 템플릿 수정 (편집 페이지에서 호출)
+  const updateTemplate = (updatedTemplate) => {
+    const index = templates.value.findIndex(t => t.id === updatedTemplate.id)
+    if (index !== -1) {
+      const today = new Date().toISOString().split('T')[0].replace(/-/g, '.')
+      templates.value[index] = {
+        ...templates.value[index],
+        ...updatedTemplate,
+        name: updatedTemplate.title,
+        updatedAt: today
+      }
+    }
+  }
+
+  // 템플릿 삭제 (목록 페이지에서 호출)
+  const deleteTemplate = (id) => {
+    templates.value = templates.value.filter(t => t.id !== id)
+  }
+
+  return { jobs, addJob, deleteJob, updateJob,
+    templates, addTemplate, updateTemplate, deleteTemplate }
 })

--- a/src/views/ApplicationTemplateCreateView.vue
+++ b/src/views/ApplicationTemplateCreateView.vue
@@ -1,9 +1,11 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useRecruitmentStore } from '@/stores/recruitment'
 
 const router = useRouter()
 const route = useRoute()
+const recruitmentStore = useRecruitmentStore()
 
 // 편집 모드 여부
 const templateId = computed(() => route.params.id)
@@ -48,21 +50,7 @@ onMounted(async () => {
 const loadTemplate = async () => {
   loading.value = true
   try {
-    // TODO: API 연동 - GET /api/v1/recruitment/templates/{templateId}
-    // 더미 데이터로 시뮬레이션
-    const dummyData = {
-      1: { title: '백엔드 개발자 지원서', customFields: [
-        { id: 'intro', label: '자기소개', type: 'long_text', required: true },
-        { id: 'portfolio', label: '포트폴리오 URL', type: 'short_text', required: false },
-      ]},
-      2: { title: '프론트엔드 개발자 지원서', customFields: [
-        { id: 'intro', label: '자기소개', type: 'long_text', required: true },
-        { id: 'github', label: 'GitHub', type: 'short_text', required: false },
-        { id: 'blog', label: '기술 블로그', type: 'short_text', required: false },
-      ]},
-    }
-
-    const data = dummyData[templateId.value]
+    const data = recruitmentStore.templates.find(t => t.id === Number(templateId.value))
     if (data) {
       templateTitle.value = data.title
       customFields.value = data.customFields || []
@@ -102,17 +90,14 @@ const handleCancel = () => {
 const handleSave = async () => {
   const payload = {
     title: templateTitle.value,
-    fields: [...defaultFields.value, ...customFields.value],
+    customFields: customFields.value,
   }
 
   if (isEditMode.value) {
-    // TODO: API 연동 - PUT /api/v1/recruitment/templates/{templateId}
-    console.log('Template updated:', templateId.value, payload)
+    recruitmentStore.updateTemplate({ id: Number(templateId.value), ...payload })
   } else {
-    // TODO: API 연동 - POST /api/v1/recruitment/templates
-    console.log('Template created:', payload)
+    recruitmentStore.addTemplate(payload)
   }
-
   router.push('/recruitment/templates')
 }
 
@@ -145,19 +130,19 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
 
       <!-- 템플릿 제목 -->
       <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-        <label class="block text-sm font-semibold text-gray-700 mb-2">제목</label>
+        <label class="block text-sm font-bold text-gray-900 mb-2">제목</label>
         <input
-          v-model="templateTitle"
-          type="text"
-          placeholder="지원서 템플릿의 제목을 입력하세요..."
-          class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+            v-model="templateTitle"
+            type="text"
+            placeholder="지원서 템플릿의 제목을 입력하세요..."
+            class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 text-gray-700 placeholder:text-gray-400"
         />
       </div>
 
       <!-- 질문 필드 -->
       <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <div class="flex items-center justify-between mb-4">
-          <label class="text-sm font-semibold text-gray-700">질문 추가</label>
+          <label class="text-sm font-bold text-gray-900">질문 추가</label>
         </div>
 
         <!-- 기본 필드 (삭제 불가) -->
@@ -178,12 +163,12 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
               <span v-if="field.placeholder" class="text-gray-400 ml-2">{{ field.placeholder }}</span>
             </div>
             <div class="flex items-center gap-3">
-              <label class="flex items-center gap-2 text-sm text-gray-600">
+              <label class="flex items-center gap-2 text-sm text-gray-600" @click.prevent>
                 <input
-                  type="checkbox"
-                  :checked="field.required"
-                  disabled
-                  class="w-4 h-4 text-brand-600 rounded border-gray-300"
+                    type="checkbox"
+                    :checked="field.required"
+                    readonly
+                    class="w-4 h-4 text-brand-600 rounded border-gray-300 pointer-events-none"
                 />
                 필수
               </label>
@@ -241,11 +226,11 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
         <div class="flex items-center gap-3">
           <div class="flex-1 relative">
             <input
-              v-model="newFieldLabel"
-              type="text"
-              placeholder="+ 질문 항목을 추가하세요..."
-              class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-              @focus="showFieldTypeDropdown = false"
+                v-model="newFieldLabel"
+                type="text"
+                placeholder="+ 질문 항목을 추가하세요..."
+                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 text-gray-700 placeholder:text-gray-400"
+                @focus="showFieldTypeDropdown = false"
             />
           </div>
           <div class="relative">

--- a/src/views/ApplicationTemplateDetailView.vue
+++ b/src/views/ApplicationTemplateDetailView.vue
@@ -1,9 +1,11 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useRecruitmentStore } from '@/stores/recruitment'
 
 const router = useRouter()
 const route = useRoute()
+const recruitmentStore = useRecruitmentStore()
 
 const templateId = computed(() => route.params.id)
 const loading = ref(true)
@@ -38,48 +40,10 @@ onMounted(async () => {
 const loadTemplate = async () => {
   loading.value = true
   try {
-    // TODO: API 연동 - GET /api/v1/recruitment/templates/{templateId}
-    // 더미 데이터로 시뮬레이션
-    const dummyData = {
-      1: {
-        id: 1,
-        title: '백엔드 개발자 지원서',
-        status: '사용중',
-        createdAt: '2024.01.15',
-        updatedAt: '2024.01.20',
-        customFields: [
-          { id: 'intro', label: '자기소개', type: 'long_text', required: true },
-          { id: 'portfolio', label: '포트폴리오 URL', type: 'short_text', required: false },
-        ]
-      },
-      2: {
-        id: 2,
-        title: '프론트엔드 개발자 지원서',
-        status: '사용중',
-        createdAt: '2024.01.18',
-        updatedAt: '2024.01.25',
-        customFields: [
-          { id: 'intro', label: '자기소개', type: 'long_text', required: true },
-          { id: 'github', label: 'GitHub', type: 'short_text', required: false },
-          { id: 'blog', label: '기술 블로그', type: 'short_text', required: false },
-        ]
-      },
-      3: {
-        id: 3,
-        title: 'DevOps 엔지니어 지원서',
-        status: '미사용',
-        createdAt: '2024.01.22',
-        updatedAt: '2024.02.01',
-        customFields: [
-          { id: 'experience', label: 'DevOps 경력 기술', type: 'long_text', required: true },
-          { id: 'certifications', label: '보유 자격증', type: 'short_text', required: false },
-        ]
-      },
-    }
-
-    template.value = dummyData[templateId.value] || null
+    const foundData = recruitmentStore.templates.find(t => t.id === Number(templateId.value))
+    template.value = foundData || null
   } catch (error) {
-    console.error('Failed to load template:', error)
+    console.error('템플릿을 불러올 수 없습니다:', error)
   } finally {
     loading.value = false
   }

--- a/src/views/ApplicationTemplateListView.vue
+++ b/src/views/ApplicationTemplateListView.vue
@@ -2,8 +2,10 @@
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
+import { useRecruitmentStore } from '@/stores/recruitment'
 
 const router = useRouter()
+const recruitmentStore = useRecruitmentStore()
 
 // 검색
 const searchQuery = ref('')
@@ -17,13 +19,7 @@ const currentPage = ref(1)
 const itemsPerPage = 5
 
 // 더미 데이터
-const templates = ref([
-  { id: 1, name: '백엔드 개발자 지원서', createdAt: '2024.01.15', updatedAt: '2024.01.20', status: '사용중' },
-  { id: 2, name: '프론트엔드 개발자 지원서', createdAt: '2024.01.18', updatedAt: '2024.01.25', status: '사용중' },
-  { id: 3, name: 'DevOps 엔지니어 지원서', createdAt: '2024.01.22', updatedAt: '2024.02.01', status: '미사용' },
-  { id: 4, name: '인턴 개발자 지원서', createdAt: '2024.02.01', updatedAt: '2024.02.01', status: '사용중' },
-  { id: 5, name: '시니어 개발자 지원서', createdAt: '2024.02.03', updatedAt: '2024.02.05', status: '미사용' },
-])
+const templates = computed(() => recruitmentStore.templates)
 
 // 필터링
 const filteredTemplates = computed(() => {
@@ -102,9 +98,7 @@ const openDeleteModal = (template) => {
 // 삭제 확인
 const handleDeleteConfirm = () => {
   if (deleteTarget.value) {
-    // TODO: API 연동 - DELETE /api/v1/recruitment/templates/{templateId}
-    templates.value = templates.value.filter(t => t.id !== deleteTarget.value.id)
-    console.log('Deleted:', deleteTarget.value.id)
+    recruitmentStore.deleteTemplate(deleteTarget.value.id)
   }
   showDeleteModal.value = false
   deleteTarget.value = null
@@ -181,7 +175,7 @@ const handleDeleteCancel = () => {
             <td class="px-6 py-4 text-gray-700">{{ template.createdAt }}</td>
 
             <!-- 수정일 -->
-            <td class="px-6 py-4 text-gray-700">{{ template.updatedAt }}</td>
+            <td class="px-6 py-4 text-gray-700">{{ template.updatedAt || '-' }}</td>
 
             <!-- 상태 -->
             <td class="px-6 py-4">


### PR DESCRIPTION
## 💡 개요
> [FE] 지원서 템플릿 CRUD 및 스토어 연동 구현

## 🔗 관련 이슈
Closes #

## 📝 작업 상세 내용
- [ ] - 지원서 템플릿 목록, 상세, 생성, 수정 페이지 UI 및 기능 구현
- [ ] Pinia (recruitment 스토어) 연동으로 기존 더미 데이터 대체
- [ ] 템플릿 생성 시 수정일은 표기하지 않고, 편집 시에만 기록되도록 로직 개선
- [ ] 목록 페이지 검색, 페이지네이션, 삭제 모달 기능 적용

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모집 템플릿 관리 기능 추가: 템플릿 생성, 수정, 삭제 가능
  * 템플릿 목록 조회 및 상세 보기 지원

* **개선 사항**
  * 템플릿 데이터 중앙화 관리로 상태 일관성 향상
  * UI 레이블 및 스타일 개선으로 사용성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->