### PR TITLE
[FE] feat: 지원자 관리 화면 개선 및 엑셀 다운로드 연동

### DIFF
--- a/src/api/applicant.js
+++ b/src/api/applicant.js
@@ -1,0 +1,291 @@
+import axios from 'axios'
+import api from './index'
+
+const shouldFallbackToWorkspaceEndpoint = (error) => {
+  const status = error?.response?.status
+  return status === 400 || status === 404 || status === 405
+}
+
+const shouldIgnoreWorkspaceFallbackError = (error) => {
+  const status = error?.response?.status
+  return status === 401 || status === 403 || shouldFallbackToWorkspaceEndpoint(error)
+}
+
+const shouldIgnoreDetailFallbackError = (error) => {
+  const status = error?.response?.status
+  return status === 401 || status === 403 || shouldFallbackToWorkspaceEndpoint(error)
+}
+
+const getWorkspaceIdFromStorage = () => {
+  const storedWorkspaceId = localStorage.getItem('workspaceId')
+  if (storedWorkspaceId) {
+    return storedWorkspaceId
+  }
+
+  const rawUser = localStorage.getItem('user')
+  if (!rawUser) {
+    return null
+  }
+
+  try {
+    const user = JSON.parse(rawUser)
+    const resolvedWorkspaceId =
+      user?.workspaceId ??
+      user?.workspace?.workspaceId ??
+      user?.workspace?.id ??
+      null
+
+    if (resolvedWorkspaceId) {
+      localStorage.setItem('workspaceId', String(resolvedWorkspaceId))
+      return String(resolvedWorkspaceId)
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+const buildTenantHeaderConfig = (workspaceId = getWorkspaceIdFromStorage()) => {
+  if (!workspaceId) {
+    return {}
+  }
+
+  return {
+    headers: {
+      'X-Tenant-ID': workspaceId
+    }
+  }
+}
+
+const normalizeKeywordParams = (params = {}) => {
+  const normalized = { ...params }
+
+  if (normalized.search && !normalized.keyword) {
+    normalized.keyword = normalized.search
+  }
+
+  if (normalized.keyword == null || normalized.keyword === '') {
+    delete normalized.keyword
+  }
+
+  return normalized
+}
+
+const toApplicantList = (payload) => {
+  if (Array.isArray(payload)) return payload
+  if (Array.isArray(payload?.content)) return payload.content
+  if (Array.isArray(payload?.items)) return payload.items
+  if (Array.isArray(payload?.applicants)) return payload.applicants
+  if (Array.isArray(payload?.rows)) return payload.rows
+  if (Array.isArray(payload?.list)) return payload.list
+  if (Array.isArray(payload?.data)) return payload.data
+  return []
+}
+
+const publicApplyApi = axios.create({
+  baseURL: api.defaults.baseURL,
+  headers: {
+    'Content-Type': 'application/json'
+  }
+})
+
+const submitToTarget = async (target, recruitmentId, payload) => {
+  try {
+    return await publicApplyApi.post(`/careers/${target}/${recruitmentId}/apply`, payload)
+  } catch (error) {
+    if (!shouldFallbackToWorkspaceEndpoint(error)) {
+      throw error
+    }
+
+    return publicApplyApi.post(`/careers/${target}/recruitments/${recruitmentId}/apply`, payload)
+  }
+}
+
+const resolveSubmitTargets = (companySlugOrWorkspaceId) => {
+  const targets = []
+  const isLoggedIn = Boolean(localStorage.getItem('accessToken'))
+  const workspaceId = getWorkspaceIdFromStorage()
+
+  if (isLoggedIn && workspaceId) {
+    targets.push(String(workspaceId))
+  }
+
+  if (!targets.includes(String(companySlugOrWorkspaceId))) {
+    targets.push(String(companySlugOrWorkspaceId))
+  }
+
+  return targets
+}
+
+export const extractResponseData = (response) => {
+  const body = response?.data
+  if (body == null) {
+    return null
+  }
+
+  const primary = body?.data ?? body
+  if (primary?.data !== undefined && !Array.isArray(primary)) {
+    return primary.data
+  }
+
+  return primary
+}
+
+export const applicantApi = {
+  async submitCareerApplication(companySlugOrWorkspaceId, recruitmentId, payload) {
+    const submitTargets = resolveSubmitTargets(companySlugOrWorkspaceId)
+    let lastError = null
+
+    for (const target of submitTargets) {
+      try {
+        return await submitToTarget(target, recruitmentId, payload)
+      } catch (error) {
+        lastError = error
+      }
+    }
+
+    throw lastError
+  },
+
+  exportApplicants(params = {}) {
+    return api.get('/applicants/export', {
+      params: normalizeKeywordParams(params),
+      ...buildTenantHeaderConfig(),
+      responseType: 'blob'
+    })
+  },
+
+  exportApplicantsExcel(params = {}) {
+    return api.get('/applicants/excel', {
+      params: normalizeKeywordParams(params),
+      ...buildTenantHeaderConfig(),
+      responseType: 'blob'
+    })
+  },
+
+  exportWorkspaceApplicants(workspaceId, params = {}) {
+    return api.get(`/workspaces/${workspaceId}/applicants/export`, {
+      params: normalizeKeywordParams(params),
+      ...buildTenantHeaderConfig(workspaceId),
+      responseType: 'blob'
+    })
+  },
+
+  exportWorkspaceApplicantsExcel(workspaceId, params = {}) {
+    return api.get(`/workspaces/${workspaceId}/applicants/excel`, {
+      params: normalizeKeywordParams(params),
+      ...buildTenantHeaderConfig(workspaceId),
+      responseType: 'blob'
+    })
+  },
+
+  async exportApplicantsWithFallback(params = {}) {
+    const workspaceId = getWorkspaceIdFromStorage()
+
+    if (workspaceId) {
+      try {
+        return await this.exportWorkspaceApplicants(workspaceId, params)
+      } catch (workspaceExportError) {
+        if (!shouldFallbackToWorkspaceEndpoint(workspaceExportError)) {
+          throw workspaceExportError
+        }
+
+        try {
+          return await this.exportWorkspaceApplicantsExcel(workspaceId, params)
+        } catch (workspaceExcelError) {
+          if (!shouldFallbackToWorkspaceEndpoint(workspaceExcelError)) {
+            throw workspaceExcelError
+          }
+        }
+      }
+    }
+
+    try {
+      return await this.exportApplicants(params)
+    } catch (primaryError) {
+      if (!shouldFallbackToWorkspaceEndpoint(primaryError)) {
+        throw primaryError
+      }
+
+      return this.exportApplicantsExcel(params)
+    }
+  },
+
+  getApplicants(params = {}) {
+    return api.get('/applicants', {
+      params: normalizeKeywordParams(params),
+      ...buildTenantHeaderConfig()
+    })
+  },
+
+  getWorkspaceApplicants(workspaceId, params = {}) {
+    return api.get(`/workspaces/${workspaceId}/applicants`, {
+      params: normalizeKeywordParams(params),
+      ...buildTenantHeaderConfig(workspaceId)
+    })
+  },
+
+  async getApplicantsWithFallback(params = {}) {
+    const workspaceId = getWorkspaceIdFromStorage()
+
+    if (workspaceId) {
+      try {
+        const workspaceResponse = await this.getWorkspaceApplicants(workspaceId, params)
+        const workspacePayload = extractResponseData(workspaceResponse)
+        const workspaceList = toApplicantList(workspacePayload)
+        if (workspaceList.length > 0) {
+          return workspaceResponse
+        }
+      } catch (workspaceError) {
+        if (!shouldIgnoreWorkspaceFallbackError(workspaceError)) {
+          throw workspaceError
+        }
+      }
+    }
+    return this.getApplicants(params)
+  },
+
+  getApplicantDetail(detailId) {
+    return api.get(`/applicants/${detailId}`, {
+      ...buildTenantHeaderConfig()
+    })
+  },
+
+  getRecruitmentApplicantDetail(detailId) {
+    return api.get(`/recruitment/applicants/${detailId}`, {
+      ...buildTenantHeaderConfig()
+    })
+  },
+
+  getWorkspaceApplicantDetail(workspaceId, detailId) {
+    return api.get(`/workspaces/${workspaceId}/applicants/${detailId}`, {
+      ...buildTenantHeaderConfig(workspaceId)
+    })
+  },
+
+  async getApplicantDetailWithFallback(detailId) {
+    const workspaceId = getWorkspaceIdFromStorage()
+
+    if (workspaceId) {
+      try {
+        return await this.getWorkspaceApplicantDetail(workspaceId, detailId)
+      } catch (workspaceError) {
+        if (!shouldIgnoreDetailFallbackError(workspaceError)) {
+          throw workspaceError
+        }
+      }
+    }
+
+    try {
+      return await this.getApplicantDetail(detailId)
+    } catch (applicantError) {
+      if (!shouldFallbackToWorkspaceEndpoint(applicantError)) {
+        throw applicantError
+      }
+    }
+
+    return this.getRecruitmentApplicantDetail(detailId)
+  },
+}
+

--- a/src/views/ApplicantDetailView.vue
+++ b/src/views/ApplicantDetailView.vue
@@ -1,106 +1,176 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { applicantApi, extractResponseData } from '@/api/applicant'
 
 const router = useRouter()
 const route = useRoute()
 
-const applicantId = computed(() => route.params.id)
+const detailId = computed(() => route.params.id)
 const loading = ref(true)
-
-// 지원자 데이터
+const loadError = ref('')
 const applicant = ref(null)
 
-// 상태별 배지 스타일
+const statusLabelMap = {
+  DOCUMENT_REVIEW: '서류 검토',
+  FIRST_INTERVIEW: '1차 면접',
+  SECOND_INTERVIEW: '2차 면접',
+  OFFER_NEGOTIATION: '처우 협의',
+  HIRED: '합격',
+  PASSED: '합격',
+  REJECTED: '불합격',
+  FAILED: '불합격'
+}
+
+const genderLabelMap = {
+  MALE: '남성',
+  FEMALE: '여성',
+  M: '남성',
+  F: '여성'
+}
+
+const normalizeStatus = (status) => {
+  if (!status) return '서류 검토'
+  return statusLabelMap[status] || status
+}
+
+const normalizeGender = (gender) => {
+  if (!gender) return '-'
+  return genderLabelMap[gender] || gender
+}
+
+const formatDate = (value) => {
+  if (!value) return '-'
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return String(value)
+  }
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}.${month}.${day}`
+}
+
+const formatDateTime = (value) => {
+  if (!value) return '-'
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return String(value)
+  }
+
+  const datePart = formatDate(date)
+  const hour = String(date.getHours()).padStart(2, '0')
+  const minute = String(date.getMinutes()).padStart(2, '0')
+
+  return `${datePart} ${hour}:${minute}`
+}
+
+const toAnswerList = (detail) => {
+  const answerList = []
+  const pushAnswer = (label, value) => {
+    if (value == null || value === '') return
+    answerList.push({ label, value: String(value) })
+  }
+
+  pushAnswer('간단 자기소개', detail?.shortBio ?? detail?.selfIntroduction)
+  pushAnswer('포트폴리오 URL', detail?.portfolioUrl ?? detail?.portfolio)
+
+  if (Array.isArray(detail?.answers)) {
+    detail.answers.forEach((item, index) => {
+      const label = item?.label ?? item?.question ?? `답변 ${index + 1}`
+      const value = item?.value ?? item?.answer
+      pushAnswer(label, value)
+    })
+  }
+
+  if (detail?.answerMap && typeof detail.answerMap === 'object') {
+    Object.entries(detail.answerMap).forEach(([label, value]) => {
+      pushAnswer(label, value)
+    })
+  }
+
+  return answerList
+}
+
+const toApplicantDetailModel = (detail) => {
+  const resumeUrl = detail?.resumeUrl ?? detail?.resumeDownloadUrl ?? detail?.resume?.url ?? null
+  const resumeName = detail?.resumeFileName ?? detail?.resumeName ?? detail?.resume?.name ?? '이력서 파일'
+
+  return {
+    id: detail?.applicationId ?? detail?.applicantId ?? detail?.id ?? detailId.value,
+    name: detail?.name ?? detail?.applicantName ?? '-',
+    email: detail?.email ?? detail?.applicantEmail ?? '-',
+    phone: detail?.phone ?? detail?.phoneNumber ?? '-',
+    gender: normalizeGender(detail?.gender ?? detail?.sex),
+    birthdate: formatDate(detail?.birthDate ?? detail?.birthdate),
+    job: detail?.recruitmentTitle ?? detail?.jobTitle ?? detail?.job ?? '-',
+    status: normalizeStatus(detail?.status ?? detail?.applicationStatus ?? detail?.progressStatus),
+    nextSchedule: formatDateTime(detail?.nextSchedule ?? detail?.nextInterviewAt ?? detail?.nextScheduleAt),
+    appliedDate: formatDate(detail?.appliedAt ?? detail?.appliedDate ?? detail?.createdAt),
+    answers: toAnswerList(detail),
+    resume: resumeUrl || resumeName ? { name: resumeName, url: resumeUrl } : null
+  }
+}
+
+const getDetailErrorMessage = (error) => {
+  return (
+    error?.response?.data?.message ||
+    error?.response?.data?.error?.message ||
+    '지원자 상세 정보를 불러오지 못했습니다.'
+  )
+}
+
+const loadApplicant = async () => {
+  if (!detailId.value) {
+    applicant.value = null
+    loading.value = false
+    loadError.value = '잘못된 접근입니다.'
+    return
+  }
+
+  loading.value = true
+  loadError.value = ''
+
+  try {
+    const response = await applicantApi.getApplicantDetailWithFallback(detailId.value)
+    const payload = extractResponseData(response)
+    const detail = payload?.applicant ?? payload?.application ?? payload?.item ?? payload
+
+    if (!detail || typeof detail !== 'object') {
+      applicant.value = null
+      loadError.value = '지원자를 찾을 수 없습니다.'
+      return
+    }
+
+    applicant.value = toApplicantDetailModel(detail)
+  } catch (error) {
+    applicant.value = null
+    loadError.value = getDetailErrorMessage(error)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadApplicant)
+watch(detailId, loadApplicant)
+
 const getStatusStyle = (status) => {
   const styles = {
     '서류 검토': 'bg-teal-100 text-teal-700 border-teal-200',
     '1차 면접': 'bg-blue-100 text-blue-700 border-blue-200',
     '2차 면접': 'bg-blue-100 text-blue-700 border-blue-200',
     '처우 협의': 'bg-amber-100 text-amber-700 border-amber-200',
-    '합격': 'bg-green-100 text-green-700 border-green-200',
-    '불합격': 'bg-gray-100 text-gray-500 border-gray-200',
+    합격: 'bg-green-100 text-green-700 border-green-200',
+    불합격: 'bg-gray-100 text-gray-500 border-gray-200'
   }
   return styles[status] || 'bg-gray-100 text-gray-700 border-gray-200'
 }
 
-// 지원자 데이터 로드
-onMounted(async () => {
-  await loadApplicant()
-})
-
-const loadApplicant = async () => {
-  loading.value = true
-  try {
-    // TODO: API 연동 - GET /api/v1/recruitment/applicants/{applicantId}
-    // 더미 데이터로 시뮬레이션
-    const dummyData = {
-      1: {
-        id: 1,
-        name: '박지원',
-        email: 'parkjiwon@email.com',
-        phone: '010-1234-5678',
-        gender: '여성',
-        birthdate: '1995-03-15',
-        job: '백엔드 개발자',
-        status: '1차 면접',
-        nextSchedule: '2024.02.06 10:00',
-        appliedDate: '2024.02.01',
-        answers: [
-          { label: '자기소개', value: '안녕하세요. 3년차 백엔드 개발자 박지원입니다. Java와 Spring Boot를 주로 사용하며, MSA 아키텍처 경험이 있습니다.' },
-          { label: '포트폴리오 URL', value: 'https://github.com/parkjiwon' },
-        ],
-        resume: { name: '박지원_이력서.pdf', url: '#' }
-      },
-      2: {
-        id: 2,
-        name: '김철수',
-        email: 'kimcs@email.com',
-        phone: '010-2345-6789',
-        gender: '남성',
-        birthdate: '1992-07-22',
-        job: '백엔드 개발자',
-        status: '2차 면접',
-        nextSchedule: '2024.02.07 14:00',
-        appliedDate: '2024.01.28',
-        answers: [
-          { label: '자기소개', value: '5년차 시니어 백엔드 개발자입니다. 대규모 트래픽 처리 경험이 있으며, 팀 리딩 경험도 있습니다.' },
-          { label: '포트폴리오 URL', value: 'https://kimcs.dev' },
-        ],
-        resume: { name: '김철수_이력서.pdf', url: '#' }
-      },
-      3: {
-        id: 3,
-        name: '이영희',
-        email: 'leeyh@email.com',
-        phone: '010-3456-7890',
-        gender: '여성',
-        birthdate: '1997-11-08',
-        job: '프론트엔드 개발자',
-        status: '서류 검토',
-        nextSchedule: null,
-        appliedDate: '2024.02.03',
-        answers: [
-          { label: '자기소개', value: 'React와 Vue.js를 사용하는 2년차 프론트엔드 개발자입니다.' },
-          { label: 'GitHub', value: 'https://github.com/leeyh' },
-          { label: '기술 블로그', value: 'https://leeyh.tistory.com' },
-        ],
-        resume: { name: '이영희_이력서.pdf', url: '#' }
-      },
-    }
-
-    applicant.value = dummyData[applicantId.value] || null
-  } catch (error) {
-    console.error('Failed to load applicant:', error)
-  } finally {
-    loading.value = false
-  }
-}
-
-// 이니셜 추출
 const getInitial = (name) => name?.charAt(0) || ''
 
-// 목록으로 돌아가기
 const goBack = () => {
   router.push('/recruitment/applicants')
 }
@@ -108,14 +178,12 @@ const goBack = () => {
 
 <template>
   <div class="max-w-3xl mx-auto space-y-6">
-    <!-- 로딩 -->
     <div v-if="loading" class="text-center py-12 text-gray-500">
       로딩 중...
     </div>
 
-    <!-- 지원자를 찾을 수 없음 -->
     <div v-else-if="!applicant" class="text-center py-12">
-      <p class="text-gray-500 mb-4">지원자를 찾을 수 없습니다.</p>
+      <p class="text-gray-500 mb-4">{{ loadError || '지원자를 찾을 수 없습니다.' }}</p>
       <button
         @click="goBack"
         class="text-brand-600 hover:text-brand-700 font-medium"
@@ -125,7 +193,6 @@ const goBack = () => {
     </div>
 
     <template v-else>
-      <!-- 헤더 -->
       <div class="flex items-center gap-3">
         <button
           @click="goBack"
@@ -138,15 +205,12 @@ const goBack = () => {
         <h1 class="text-2xl font-bold text-gray-900">지원자 상세</h1>
       </div>
 
-      <!-- 기본 정보 -->
       <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <div class="flex items-start gap-4">
-          <!-- 프로필 아바타 -->
           <div class="w-16 h-16 rounded-full bg-brand-100 flex items-center justify-center text-brand-600 text-2xl font-bold">
             {{ getInitial(applicant.name) }}
           </div>
 
-          <!-- 정보 -->
           <div class="flex-1">
             <div class="flex items-center gap-3 mb-1">
               <h2 class="text-xl font-bold text-gray-900">{{ applicant.name }}</h2>
@@ -160,7 +224,6 @@ const goBack = () => {
           </div>
         </div>
 
-        <!-- 상세 정보 그리드 -->
         <div class="grid grid-cols-2 gap-4 mt-6 pt-6 border-t border-gray-100">
           <div>
             <p class="text-sm text-gray-500 mb-1">이메일</p>
@@ -189,11 +252,14 @@ const goBack = () => {
         </div>
       </div>
 
-      <!-- 이력서 -->
       <div v-if="applicant.resume" class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">이력서</h3>
+
         <a
+          v-if="applicant.resume.url"
           :href="applicant.resume.url"
+          target="_blank"
+          rel="noopener noreferrer"
           class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
         >
           <div class="w-10 h-10 bg-red-100 rounded-lg flex items-center justify-center">
@@ -203,16 +269,26 @@ const goBack = () => {
           </div>
           <div class="flex-1">
             <p class="font-medium text-gray-900">{{ applicant.resume.name }}</p>
-            <p class="text-sm text-gray-500">PDF 문서</p>
+            <p class="text-sm text-gray-500">파일 다운로드</p>
           </div>
-          <svg class="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-          </svg>
         </a>
+
+        <div
+          v-else
+          class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg bg-gray-50"
+        >
+          <div class="w-10 h-10 bg-red-100 rounded-lg flex items-center justify-center">
+            <svg class="w-5 h-5 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <div class="flex-1">
+            <p class="font-medium text-gray-900">{{ applicant.resume.name }}</p>
+          </div>
+        </div>
       </div>
 
-      <!-- 지원서 답변 -->
-      <div v-if="applicant.answers && applicant.answers.length > 0" class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <div v-if="applicant.answers.length > 0" class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <h3 class="text-lg font-semibold text-gray-900 mb-4">지원서 답변</h3>
         <div class="space-y-6">
           <div
@@ -225,7 +301,6 @@ const goBack = () => {
         </div>
       </div>
 
-      <!-- 하단 버튼 -->
       <div class="flex items-center justify-start pt-4">
         <button
           @click="goBack"

--- a/src/views/ApplicantListView.vue
+++ b/src/views/ApplicantListView.vue
@@ -1,81 +1,192 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import * as XLSX from 'xlsx'
+import { applicantApi, extractResponseData } from '@/api/applicant'
 
 const router = useRouter()
 
-// 검색 및 필터
 const searchQuery = ref('')
 const selectedJob = ref('')
 const selectedStatus = ref('')
 
-// 페이지네이션
 const currentPage = ref(1)
 const itemsPerPage = 5
 
-// 더미 데이터
-const applicants = ref([
-  { id: 1, name: '박지원', email: 'parkjiwon@email.com', job: '백엔드 개발자', status: '1차 면접', nextSchedule: '2024.02.06 10:00', appliedDate: '2024.02.01' },
-  { id: 2, name: '김철수', email: 'kimcs@email.com', job: '백엔드 개발자', status: '2차 면접', nextSchedule: '2024.02.07 14:00', appliedDate: '2024.01.28' },
-  { id: 3, name: '이영희', email: 'leeyh@email.com', job: '프론트엔드 개발자', status: '서류 검토', nextSchedule: null, appliedDate: '2024.02.03' },
-  { id: 4, name: '최민수', email: 'choi.ms@email.com', job: '백엔드 개발자', status: '처우 협의', nextSchedule: '2024.02.08 15:00', appliedDate: '2024.01.20' },
-  { id: 5, name: '정수현', email: 'jung.sh@email.com', job: '백엔드 개발자', status: '불합격', nextSchedule: null, appliedDate: '2024.01.25' },
-  { id: 6, name: '한소영', email: 'hansoy@email.com', job: '프론트엔드 개발자', status: '1차 면접', nextSchedule: '2024.02.09 11:00', appliedDate: '2024.02.02' },
-  { id: 7, name: '오준석', email: 'ohjs@email.com', job: 'DevOps 엔지니어', status: '서류 검토', nextSchedule: null, appliedDate: '2024.02.04' },
-  { id: 8, name: '윤지민', email: 'yoonjm@email.com', job: '백엔드 개발자', status: '합격', nextSchedule: null, appliedDate: '2024.01.15' },
-])
+const applicants = ref([])
+const loading = ref(false)
+const loadError = ref('')
+const isExporting = ref(false)
 
-const jobs = ['백엔드 개발자', '프론트엔드 개발자', 'DevOps 엔지니어']
-const statuses = ['서류 검토', '1차 면접', '2차 면접', '처우 협의', '합격', '불합격']
+const defaultStatuses = ['서류 검토', '1차 면접', '2차 면접', '처우 협의', '합격', '불합격']
 
-// 필터링된 지원자 목록
+const statusLabelMap = {
+  DOCUMENT_REVIEW: '서류 검토',
+  FIRST_INTERVIEW: '1차 면접',
+  SECOND_INTERVIEW: '2차 면접',
+  OFFER_NEGOTIATION: '처우 협의',
+  HIRED: '합격',
+  PASSED: '합격',
+  REJECTED: '불합격',
+  FAILED: '불합격'
+}
+
+const normalizeStatus = (status) => {
+  if (!status) return '서류 검토'
+  return statusLabelMap[status] || status
+}
+
+const formatDate = (value) => {
+  if (!value) return '-'
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return String(value)
+  }
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}.${month}.${day}`
+}
+
+const formatDateTime = (value) => {
+  if (!value) return null
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return String(value)
+  }
+
+  const base = formatDate(date)
+  const hour = String(date.getHours()).padStart(2, '0')
+  const minute = String(date.getMinutes()).padStart(2, '0')
+  return `${base} ${hour}:${minute}`
+}
+
+const toApplicantArray = (payload) => {
+  if (Array.isArray(payload)) return payload
+  if (Array.isArray(payload?.content)) return payload.content
+  if (Array.isArray(payload?.items)) return payload.items
+  if (Array.isArray(payload?.applicants)) return payload.applicants
+  return []
+}
+
+const toDisplayApplicant = (item, index) => {
+  const detailId = item?.applicationId ?? item?.applicantId ?? item?.id ?? `applicant-${index}`
+  const id = item?.id ?? detailId
+  const name = item?.name ?? item?.applicantName ?? '-'
+  const email = item?.email ?? item?.applicantEmail ?? '-'
+  const job = item?.recruitmentTitle ?? item?.jobTitle ?? item?.job ?? '-'
+  const status = normalizeStatus(item?.status ?? item?.applicationStatus ?? item?.progressStatus)
+  const nextSchedule = formatDateTime(item?.nextSchedule ?? item?.nextInterviewAt ?? item?.nextScheduleAt)
+  const appliedDate = formatDate(item?.appliedAt ?? item?.appliedDate ?? item?.createdAt)
+
+  return {
+    id,
+    detailId,
+    name,
+    email,
+    job,
+    status,
+    nextSchedule,
+    appliedDate
+  }
+}
+
+const getListErrorMessage = (error) => {
+  return (
+    error?.response?.data?.message ||
+    error?.response?.data?.error?.message ||
+    '지원자 목록을 불러오지 못했습니다.'
+  )
+}
+
+const loadApplicants = async () => {
+  loading.value = true
+  loadError.value = ''
+
+  try {
+    const response = await applicantApi.getApplicantsWithFallback()
+    const payload = extractResponseData(response)
+    const list = toApplicantArray(payload)
+    applicants.value = list.map(toDisplayApplicant)
+  } catch (error) {
+    applicants.value = []
+    loadError.value = getListErrorMessage(error)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  loadApplicants()
+})
+
+const jobs = computed(() => {
+  return [...new Set(applicants.value.map((applicant) => applicant.job).filter((job) => job && job !== '-'))]
+})
+
+const statuses = computed(() => {
+  return [...new Set([...defaultStatuses, ...applicants.value.map((applicant) => applicant.status).filter(Boolean)])]
+})
+
 const filteredApplicants = computed(() => {
-  return applicants.value.filter(applicant => {
-    const matchesSearch = !searchQuery.value ||
-      applicant.name.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
-      applicant.email.toLowerCase().includes(searchQuery.value.toLowerCase())
+  return applicants.value.filter((applicant) => {
+    const keyword = searchQuery.value.trim().toLowerCase()
+    const name = (applicant.name || '').toLowerCase()
+    const email = (applicant.email || '').toLowerCase()
+
+    const matchesSearch = !keyword || name.includes(keyword) || email.includes(keyword)
     const matchesJob = !selectedJob.value || applicant.job === selectedJob.value
     const matchesStatus = !selectedStatus.value || applicant.status === selectedStatus.value
+
     return matchesSearch && matchesJob && matchesStatus
   })
 })
 
-// 페이지네이션
-const totalPages = computed(() => Math.ceil(filteredApplicants.value.length / itemsPerPage))
+const totalPages = computed(() => {
+  return Math.max(1, Math.ceil(filteredApplicants.value.length / itemsPerPage))
+})
+
 const paginatedApplicants = computed(() => {
   const start = (currentPage.value - 1) * itemsPerPage
   return filteredApplicants.value.slice(start, start + itemsPerPage)
 })
 
 const totalCount = computed(() => filteredApplicants.value.length)
-const startIndex = computed(() => (currentPage.value - 1) * itemsPerPage + 1)
-const endIndex = computed(() => Math.min(currentPage.value * itemsPerPage, totalCount.value))
+const startIndex = computed(() => (totalCount.value === 0 ? 0 : (currentPage.value - 1) * itemsPerPage + 1))
+const endIndex = computed(() => (totalCount.value === 0 ? 0 : Math.min(currentPage.value * itemsPerPage, totalCount.value)))
 
-// 상태별 배지 스타일
+watch([searchQuery, selectedJob, selectedStatus], () => {
+  currentPage.value = 1
+})
+
+watch(filteredApplicants, () => {
+  if (currentPage.value > totalPages.value) {
+    currentPage.value = totalPages.value
+  }
+})
+
 const getStatusStyle = (status) => {
   const styles = {
     '서류 검토': 'bg-teal-100 text-teal-700 border-teal-200',
     '1차 면접': 'bg-blue-100 text-blue-700 border-blue-200',
     '2차 면접': 'bg-blue-100 text-blue-700 border-blue-200',
     '처우 협의': 'bg-amber-100 text-amber-700 border-amber-200',
-    '합격': 'bg-green-100 text-green-700 border-green-200',
-    '불합격': 'bg-gray-100 text-gray-500 border-gray-200',
+    합격: 'bg-green-100 text-green-700 border-green-200',
+    불합격: 'bg-gray-100 text-gray-500 border-gray-200'
   }
   return styles[status] || 'bg-gray-100 text-gray-700 border-gray-200'
 }
 
-// 이니셜 추출
-const getInitial = (name) => name.charAt(0)
+const getInitial = (name) => (name ? name.charAt(0) : '-')
 
-// 페이지 변경
 const goToPage = (page) => {
   if (page >= 1 && page <= totalPages.value) {
     currentPage.value = page
   }
 }
 
-// 페이지 번호 목록
 const pageNumbers = computed(() => {
   const pages = []
   const total = totalPages.value
@@ -83,59 +194,108 @@ const pageNumbers = computed(() => {
 
   if (total <= 5) {
     for (let i = 1; i <= total; i++) pages.push(i)
+  } else if (current <= 3) {
+    pages.push(1, 2, 3, '...', total)
+  } else if (current >= total - 2) {
+    pages.push(1, '...', total - 2, total - 1, total)
   } else {
-    if (current <= 3) {
-      pages.push(1, 2, 3, '...', total)
-    } else if (current >= total - 2) {
-      pages.push(1, '...', total - 2, total - 1, total)
-    } else {
-      pages.push(1, '...', current, '...', total)
-    }
+    pages.push(1, '...', current, '...', total)
   }
+
   return pages
 })
 
-// 지원자 상세보기
-const goToDetail = (applicantId) => {
-  router.push(`/recruitment/applicants/${applicantId}`)
+const goToDetail = (detailId) => {
+  router.push(`/recruitment/applicants/${detailId}`)
 }
 
-// 엑셀 다운로드
-const exportToExcel = () => {
-  // 1) 엑셀에 들어갈 데이터 준비 (현재 필터링된 전체 데이터)
-  const excelData = filteredApplicants.value.map(applicant => ({
-    '이름': applicant.name,
-    '이메일': applicant.email,
-    '지원 공고': applicant.job,
-    '진행 상태': applicant.status,
-    '다음 일정': applicant.nextSchedule || '-',
-    '지원일': applicant.appliedDate
-  }))
+const buildExportParams = () => {
+  const params = {}
+  const search = searchQuery.value.trim()
 
-  // 데이터가 없을 경우 처리
-  if (excelData.length === 0) {
-    alert('다운로드할 지원자 데이터가 없습니다.')
-    return
+  if (search) params.search = search
+  if (selectedJob.value) params.job = selectedJob.value
+  if (selectedStatus.value) params.status = selectedStatus.value
+
+  return params
+}
+
+const getDefaultExportFilename = () => {
+  const today = new Date().toISOString().split('T')[0]
+  return `applicants_${today}.xlsx`
+}
+
+const getFilenameFromContentDisposition = (contentDisposition) => {
+  if (!contentDisposition) return null
+
+  const utf8Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i)
+  if (utf8Match?.[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1].replace(/\"/g, '').trim())
+    } catch {
+      return utf8Match[1].replace(/\"/g, '').trim()
+    }
   }
 
-  // 2) 엑셀 워크시트(Sheet)와 워크북(파일) 생성
-  const worksheet = XLSX.utils.json_to_sheet(excelData)
-  const workbook = XLSX.utils.book_new()
-  XLSX.utils.book_append_sheet(workbook, worksheet, '지원자 목록')
+  const asciiMatch = contentDisposition.match(/filename=\"?([^\";]+)\"?/i)
+  if (asciiMatch?.[1]) {
+    return asciiMatch[1].trim()
+  }
 
-  // 3) 파일명에 오늘 날짜 붙여서 다운로드 실행
-  const today = new Date().toISOString().split('T')[0] // 예: 2024-02-20
-  XLSX.writeFile(workbook, `지원자_목록_${today}.xlsx`)
+  return null
 }
+
+const triggerDownload = (blob, filename) => {
+  const blobUrl = window.URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = blobUrl
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  window.URL.revokeObjectURL(blobUrl)
+}
+
+const getExportErrorMessage = (error) => {
+  return (
+    error?.response?.data?.message ||
+    error?.response?.data?.error?.message ||
+    '엑셀 파일 다운로드에 실패했습니다.'
+  )
+}
+
+const exportToExcel = async () => {
+  if (isExporting.value) return
+
+  isExporting.value = true
+
+  try {
+    const response = await applicantApi.exportApplicantsWithFallback(buildExportParams())
+    const contentType = response?.headers?.['content-type'] || 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    const blob = response?.data instanceof Blob
+      ? response.data
+      : new Blob([response?.data], { type: contentType })
+
+    const filename = getFilenameFromContentDisposition(response?.headers?.['content-disposition']) || getDefaultExportFilename()
+    triggerDownload(blob, filename)
+  } catch (error) {
+    alert(getExportErrorMessage(error))
+  } finally {
+    isExporting.value = false
+  }
+}
+
+const emptyMessage = computed(() => {
+  if (loading.value) return '지원자 목록을 불러오는 중입니다.'
+  if (loadError.value) return loadError.value
+  return '검색 결과가 없습니다.'
+})
 </script>
 
 <template>
   <div class="space-y-6">
-    <!-- 헤더 -->
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-      <!-- 필터 영역 -->
       <div class="flex flex-wrap items-center gap-3">
-        <!-- 검색 -->
         <div class="relative">
           <input
             v-model="searchQuery"
@@ -148,7 +308,6 @@ const exportToExcel = () => {
           </svg>
         </div>
 
-        <!-- 공고 필터 -->
         <select
           v-model="selectedJob"
           class="px-4 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white"
@@ -157,7 +316,6 @@ const exportToExcel = () => {
           <option v-for="job in jobs" :key="job" :value="job">{{ job }}</option>
         </select>
 
-        <!-- 상태 필터 -->
         <select
           v-model="selectedStatus"
           class="px-4 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white"
@@ -165,13 +323,12 @@ const exportToExcel = () => {
           <option value="">모든 상태</option>
           <option v-for="status in statuses" :key="status" :value="status">{{ status }}</option>
         </select>
-
       </div>
 
-      <!-- 엑셀 다운로드 버튼 -->
       <button
         @click="exportToExcel"
-        class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors sm:ml-auto"
+        :disabled="isExporting || loading"
+        class="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors sm:ml-auto disabled:opacity-60 disabled:cursor-not-allowed"
       >
         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -180,7 +337,6 @@ const exportToExcel = () => {
       </button>
     </div>
 
-    <!-- 테이블 -->
     <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
       <table class="w-full">
         <thead class="bg-gray-50 border-b border-gray-200">
@@ -199,7 +355,6 @@ const exportToExcel = () => {
             :key="applicant.id"
             class="hover:bg-gray-50 transition-colors"
           >
-            <!-- 지원자 정보 -->
             <td class="px-6 py-4">
               <div class="flex items-center gap-3">
                 <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-gray-600 font-medium">
@@ -207,7 +362,7 @@ const exportToExcel = () => {
                 </div>
                 <div>
                   <button
-                    @click="goToDetail(applicant.id)"
+                    @click="goToDetail(applicant.detailId)"
                     class="font-medium text-gray-900 hover:text-brand-600 transition-colors text-left"
                   >
                     {{ applicant.name }}
@@ -217,10 +372,8 @@ const exportToExcel = () => {
               </div>
             </td>
 
-            <!-- 공고 -->
             <td class="px-6 py-4 text-gray-700">{{ applicant.job }}</td>
 
-            <!-- 진행 상태 -->
             <td class="px-6 py-4">
               <span
                 :class="[getStatusStyle(applicant.status), 'px-3 py-1 rounded-full text-sm font-medium border']"
@@ -229,19 +382,16 @@ const exportToExcel = () => {
               </span>
             </td>
 
-            <!-- 다음 일정 -->
             <td class="px-6 py-4 text-gray-700">
               {{ applicant.nextSchedule || '-' }}
             </td>
 
-            <!-- 지원일 -->
             <td class="px-6 py-4 text-gray-700">{{ applicant.appliedDate }}</td>
 
-            <!-- 액션 -->
             <td class="px-6 py-4 text-right">
               <div class="flex items-center justify-end gap-3">
                 <button
-                  @click="goToDetail(applicant.id)"
+                  @click="goToDetail(applicant.detailId)"
                   class="text-brand-600 hover:text-brand-700 text-sm font-medium"
                 >
                   상세
@@ -250,23 +400,20 @@ const exportToExcel = () => {
             </td>
           </tr>
 
-          <!-- 빈 상태 -->
           <tr v-if="paginatedApplicants.length === 0">
             <td colspan="6" class="px-6 py-12 text-center text-gray-500">
-              검색 결과가 없습니다.
+              {{ emptyMessage }}
             </td>
           </tr>
         </tbody>
       </table>
 
-      <!-- 페이지네이션 -->
       <div class="px-6 py-4 border-t border-gray-200 flex items-center justify-between bg-gray-50">
         <p class="text-sm text-gray-600">
           총 {{ totalCount }}명 중 {{ startIndex }}-{{ endIndex }}
         </p>
 
         <div class="flex items-center gap-1">
-          <!-- 이전 -->
           <button
             @click="goToPage(currentPage - 1)"
             :disabled="currentPage === 1"
@@ -277,7 +424,6 @@ const exportToExcel = () => {
             </svg>
           </button>
 
-          <!-- 페이지 번호 -->
           <template v-for="(page, index) in pageNumbers" :key="index">
             <span v-if="page === '...'" class="px-2 text-gray-400">...</span>
             <button
@@ -294,7 +440,6 @@ const exportToExcel = () => {
             </button>
           </template>
 
-          <!-- 다음 -->
           <button
             @click="goToPage(currentPage + 1)"
             :disabled="currentPage === totalPages"

--- a/src/views/ApplicationTemplateCreateView.vue
+++ b/src/views/ApplicationTemplateCreateView.vue
@@ -7,90 +7,80 @@ const router = useRouter()
 const route = useRoute()
 const recruitmentStore = useRecruitmentStore()
 
-// 편집 모드 여부
 const templateId = computed(() => route.params.id)
 const isEditMode = computed(() => !!templateId.value)
 const loading = ref(false)
 
-// 템플릿 데이터
 const templateTitle = ref('')
 
-// 기본 필드 (삭제 불가)
 const defaultFields = ref([
   { id: 'name', label: '이름', type: 'text', required: true, editable: false },
   { id: 'gender', label: '성별', type: 'select', options: '남성 / 여성', required: true, editable: false },
   { id: 'birthdate', label: '생년월일', type: 'date', placeholder: 'YYYY-MM-DD', required: true, editable: false },
   { id: 'phone', label: '연락처', type: 'text', required: true, editable: false },
+  { id: 'email', label: '이메일', type: 'email', required: true, editable: false },
+  { id: 'shortBio', label: '간단 자기소개', type: 'long_text', required: true, editable: false }
 ])
 
-// 추가 질문 필드
 const customFields = ref([])
 
-// 필드 타입 옵션
 const fieldTypeOptions = [
   { value: 'short_text', label: '단답형 질문', icon: 'text' },
   { value: 'long_text', label: '장문형 질문', icon: 'paragraph' },
   { value: 'select', label: '선택형 질문', icon: 'list' },
   { value: 'checkbox', label: '체크박스', icon: 'check' },
-  { value: 'file', label: '첨부파일', icon: 'attachment' },
+  { value: 'file', label: '첨부 파일', icon: 'attachment' }
 ]
 
-// 드롭다운 상태
 const showFieldTypeDropdown = ref(false)
 const newFieldLabel = ref('')
 
-// 편집 모드일 때 데이터 로드
 onMounted(async () => {
   if (isEditMode.value) {
     await loadTemplate()
   }
 })
 
-// 템플릿 데이터 로드
 const loadTemplate = async () => {
   loading.value = true
   try {
-    const data = recruitmentStore.templates.find(t => t.id === Number(templateId.value))
+    const data = recruitmentStore.templates.find((template) => template.id === Number(templateId.value))
     if (data) {
       templateTitle.value = data.title
       customFields.value = data.customFields || []
     }
   } catch (error) {
-    console.error('Failed to load template:', error)
+    console.error('템플릿을 불러오지 못했습니다:', error)
   } finally {
     loading.value = false
   }
 }
 
-// 새 필드 추가
 const addField = (type) => {
-  const typeOption = fieldTypeOptions.find(opt => opt.value === type)
+  const typeOption = fieldTypeOptions.find((option) => option.value === type)
   customFields.value.push({
     id: `custom_${Date.now()}`,
     label: newFieldLabel.value || `새 ${typeOption.label}`,
-    type: type,
+    type,
     required: false,
-    options: type === 'select' ? '옵션1 / 옵션2' : '',
+    options: type === 'select' ? '옵션1 / 옵션2' : ''
   })
   newFieldLabel.value = ''
   showFieldTypeDropdown.value = false
 }
 
-// 필드 삭제
 const removeField = (index) => {
   customFields.value.splice(index, 1)
 }
 
-// 취소
 const handleCancel = () => {
   router.push('/recruitment/templates')
 }
 
-// 저장
 const handleSave = async () => {
   const payload = {
     title: templateTitle.value,
-    customFields: customFields.value,
+    customFields: customFields.value
   }
 
   if (isEditMode.value) {
@@ -98,54 +88,48 @@ const handleSave = async () => {
   } else {
     recruitmentStore.addTemplate(payload)
   }
+
   router.push('/recruitment/templates')
 }
 
-// 필드 타입 라벨 가져오기
 const getFieldTypeLabel = (type) => {
-  const option = fieldTypeOptions.find(opt => opt.value === type)
+  const option = fieldTypeOptions.find((value) => value.value === type)
   return option ? option.label : type
 }
 
-// 페이지 제목
-const pageTitle = computed(() => isEditMode.value ? '지원서 템플릿 수정' : '지원서 템플릿 작성')
-const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
+const pageTitle = computed(() => (isEditMode.value ? '지원서 템플릿 수정' : '지원서 템플릿 생성'))
+const saveButtonText = computed(() => (isEditMode.value ? '저장' : '적용'))
 </script>
 
 <template>
   <div class="max-w-3xl mx-auto space-y-6">
-    <!-- 로딩 -->
     <div v-if="loading" class="text-center py-12 text-gray-500">
       로딩 중...
     </div>
 
     <template v-else>
-      <!-- 헤더 -->
       <div>
         <h1 class="text-2xl font-bold text-gray-900">{{ pageTitle }}</h1>
         <p class="mt-2 text-gray-600">
-          지원서 템플릿의 제목을 설정하고 필요한 질문 항목을 추가하여 지원서를 작성할 수 있도록 설정해 주세요.
+          지원서 템플릿의 제목을 설정하고 필요한 질문 항목을 추가하여 지원서 양식을 만들어 주세요.
         </p>
       </div>
 
-      <!-- 템플릿 제목 -->
       <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <label class="block text-sm font-bold text-gray-900 mb-2">제목</label>
         <input
-            v-model="templateTitle"
-            type="text"
-            placeholder="지원서 템플릿의 제목을 입력하세요..."
-            class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 text-gray-700 placeholder:text-gray-400"
+          v-model="templateTitle"
+          type="text"
+          placeholder="지원서 템플릿 제목을 입력해 주세요..."
+          class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 text-gray-700 placeholder:text-gray-400"
         />
       </div>
 
-      <!-- 질문 필드 -->
       <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <div class="flex items-center justify-between mb-4">
           <label class="text-sm font-bold text-gray-900">질문 추가</label>
         </div>
 
-        <!-- 기본 필드 (삭제 불가) -->
         <div class="space-y-3 mb-6">
           <div
             v-for="field in defaultFields"
@@ -165,10 +149,10 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
             <div class="flex items-center gap-3">
               <label class="flex items-center gap-2 text-sm text-gray-600" @click.prevent>
                 <input
-                    type="checkbox"
-                    :checked="field.required"
-                    readonly
-                    class="w-4 h-4 text-brand-600 rounded border-gray-300 pointer-events-none"
+                  type="checkbox"
+                  :checked="field.required"
+                  readonly
+                  class="w-4 h-4 text-brand-600 rounded border-gray-300 pointer-events-none"
                 />
                 필수
               </label>
@@ -177,10 +161,8 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
           </div>
         </div>
 
-        <!-- 구분선 -->
         <div class="border-t border-gray-200 my-6"></div>
 
-        <!-- 추가 질문 필드 -->
         <div class="space-y-3 mb-6">
           <div
             v-for="(field, index) in customFields"
@@ -197,7 +179,7 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
                 v-model="field.label"
                 type="text"
                 class="w-full bg-transparent border-none focus:ring-0 p-0 text-gray-700"
-                placeholder="질문을 입력하세요..."
+                placeholder="질문을 입력해 주세요..."
               />
               <span class="text-xs text-gray-400">{{ getFieldTypeLabel(field.type) }}</span>
             </div>
@@ -222,15 +204,14 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
           </div>
         </div>
 
-        <!-- 새 질문 추가 -->
         <div class="flex items-center gap-3">
           <div class="flex-1 relative">
             <input
-                v-model="newFieldLabel"
-                type="text"
-                placeholder="+ 질문 항목을 추가하세요..."
-                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 text-gray-700 placeholder:text-gray-400"
-                @focus="showFieldTypeDropdown = false"
+              v-model="newFieldLabel"
+              type="text"
+              placeholder="+ 질문 항목을 추가해 주세요..."
+              class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 text-gray-700 placeholder:text-gray-400"
+              @focus="showFieldTypeDropdown = false"
             />
           </div>
           <div class="relative">
@@ -244,7 +225,6 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
               필드 추가
             </button>
 
-            <!-- 드롭다운 메뉴 -->
             <div
               v-if="showFieldTypeDropdown"
               class="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-10"
@@ -277,12 +257,10 @@ const saveButtonText = computed(() => isEditMode.value ? '저장' : '적용')
         </div>
       </div>
 
-      <!-- 안내 문구 -->
       <p class="text-sm text-gray-500 text-center">
         지원서를 제출하면 '<span class="text-brand-600 underline cursor-pointer">개인정보</span>' 처리방침에 동의하게 됩니다.
       </p>
 
-      <!-- 버튼 영역 -->
       <div class="flex items-center justify-end gap-3 pt-4">
         <button
           @click="handleCancel"

--- a/src/views/ApplicationTemplateDetailView.vue
+++ b/src/views/ApplicationTemplateDetailView.vue
@@ -9,19 +9,17 @@ const recruitmentStore = useRecruitmentStore()
 
 const templateId = computed(() => route.params.id)
 const loading = ref(true)
-
-// 템플릿 데이터
 const template = ref(null)
 
-// 기본 필드 (항상 포함)
 const defaultFields = [
   { id: 'name', label: '이름', type: 'text', required: true },
   { id: 'gender', label: '성별', type: 'select', options: '남성 / 여성', required: true },
   { id: 'birthdate', label: '생년월일', type: 'date', placeholder: 'YYYY-MM-DD', required: true },
   { id: 'phone', label: '연락처', type: 'text', required: true },
+  { id: 'email', label: '이메일', type: 'email', required: true },
+  { id: 'shortBio', label: '간단 자기소개', type: 'long_text', required: true }
 ]
 
-// 필드 타입 라벨
 const fieldTypeLabels = {
   text: '텍스트',
   date: '날짜',
@@ -29,10 +27,9 @@ const fieldTypeLabels = {
   short_text: '단답형 질문',
   long_text: '장문형 질문',
   checkbox: '체크박스',
-  file: '첨부파일',
+  file: '첨부 파일'
 }
 
-// 템플릿 데이터 로드
 onMounted(async () => {
   await loadTemplate()
 })
@@ -40,26 +37,23 @@ onMounted(async () => {
 const loadTemplate = async () => {
   loading.value = true
   try {
-    const foundData = recruitmentStore.templates.find(t => t.id === Number(templateId.value))
+    const foundData = recruitmentStore.templates.find((item) => item.id === Number(templateId.value))
     template.value = foundData || null
   } catch (error) {
-    console.error('템플릿을 불러올 수 없습니다:', error)
+    console.error('템플릿을 불러오지 못했습니다:', error)
   } finally {
     loading.value = false
   }
 }
 
-// 필드 타입 라벨 가져오기
 const getFieldTypeLabel = (type) => {
   return fieldTypeLabels[type] || type
 }
 
-// 편집 페이지로 이동
 const goToEdit = () => {
   router.push(`/recruitment/templates/${templateId.value}/edit`)
 }
 
-// 목록으로 돌아가기
 const goBack = () => {
   router.push('/recruitment/templates')
 }
@@ -67,12 +61,10 @@ const goBack = () => {
 
 <template>
   <div class="max-w-3xl mx-auto space-y-6">
-    <!-- 로딩 -->
     <div v-if="loading" class="text-center py-12 text-gray-500">
       로딩 중...
     </div>
 
-    <!-- 템플릿을 찾을 수 없음 -->
     <div v-else-if="!template" class="text-center py-12">
       <p class="text-gray-500 mb-4">템플릿을 찾을 수 없습니다.</p>
       <button
@@ -84,7 +76,6 @@ const goBack = () => {
     </div>
 
     <template v-else>
-      <!-- 헤더 -->
       <div class="flex items-center justify-between">
         <div>
           <div class="flex items-center gap-3 mb-2">
@@ -99,7 +90,7 @@ const goBack = () => {
             <h1 class="text-2xl font-bold text-gray-900">{{ template.title }}</h1>
             <span
               :class="[
-                template.status === '사용중'
+                template.status === '사용중' || template.status === '사용 중'
                   ? 'bg-green-100 text-green-700 border-green-200'
                   : 'bg-gray-100 text-gray-500 border-gray-200',
                 'px-3 py-1 rounded-full text-sm font-medium border'
@@ -109,7 +100,7 @@ const goBack = () => {
             </span>
           </div>
           <p class="text-gray-500 text-sm ml-8">
-            생성일: {{ template.createdAt }} · 수정일: {{ template.updatedAt }}
+            생성일 {{ template.createdAt }} · 수정일 {{ template.updatedAt }}
           </p>
         </div>
         <button
@@ -119,11 +110,10 @@ const goBack = () => {
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
           </svg>
-          편집
+          수정
         </button>
       </div>
 
-      <!-- 기본 필드 섹션 -->
       <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <h2 class="text-lg font-semibold text-gray-900 mb-4">기본 항목</h2>
         <p class="text-sm text-gray-500 mb-4">모든 지원서에 기본으로 포함되는 항목입니다.</p>
@@ -147,7 +137,6 @@ const goBack = () => {
         </div>
       </div>
 
-      <!-- 추가 질문 섹션 -->
       <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <h2 class="text-lg font-semibold text-gray-900 mb-4">추가 질문</h2>
 
@@ -170,11 +159,10 @@ const goBack = () => {
         </div>
 
         <div v-else class="text-center py-8 text-gray-500">
-          추가된 질문이 없습니다.
+          추가한 질문이 없습니다.
         </div>
       </div>
 
-      <!-- 하단 버튼 -->
       <div class="flex items-center justify-between pt-4">
         <button
           @click="goBack"
@@ -186,7 +174,7 @@ const goBack = () => {
           @click="goToEdit"
           class="px-6 py-2.5 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors font-medium"
         >
-          편집하기
+          수정하기
         </button>
       </div>
     </template>

--- a/src/views/CareersApplyView.vue
+++ b/src/views/CareersApplyView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { applicantApi } from '@/api/applicant'
 
 const route = useRoute()
 const router = useRouter()
@@ -8,22 +9,22 @@ const router = useRouter()
 const companySlug = computed(() => route.params.companySlug)
 const jobId = computed(() => route.params.jobId)
 
-// 더미 회사 정보
 const companyInfo = {
   naver: { name: 'NAVER', logo: 'N' },
-  kakao: { name: 'Kakao', logo: 'K' },
+  kakao: { name: 'Kakao', logo: 'K' }
 }
 
-const company = computed(() => companyInfo[companySlug.value] || { name: companySlug.value, logo: companySlug.value?.charAt(0)?.toUpperCase() })
+const company = computed(() => companyInfo[companySlug.value] || {
+  name: companySlug.value,
+  logo: companySlug.value?.charAt(0)?.toUpperCase()
+})
 
-// 템플릿 데이터 (API에서 받아올 JSON)
 const template = ref(null)
 const loading = ref(true)
 
-// 폼 데이터
 const formData = ref({})
+const submitting = ref(false)
 
-// 더미 템플릿 데이터 (실제로는 API에서 templateId로 조회)
 const dummyTemplates = {
   'tpl-1': {
     id: 'tpl-1',
@@ -35,8 +36,8 @@ const dummyTemplates = {
       { id: 'birthdate', type: 'date', label: '생년월일', required: true, placeholder: 'YYYY-MM-DD' },
       { id: 'phone', type: 'text', label: '번호', required: true, placeholder: '010-0000-0000' },
       { id: 'email', type: 'email', label: '이메일', required: true, placeholder: 'example@email.com' },
-      { id: 'intro', type: 'textarea', label: '간단 자기소개', required: true, placeholder: '자기소개를 입력하세요...', maxLength: 500 },
-      { id: 'portfolio', type: 'text', label: '포트폴리오 URL', required: false, placeholder: 'https://github.com/...' },
+      { id: 'shortBio', type: 'textarea', label: '간단 자기소개', required: true, placeholder: '자기소개를 입력하세요...', maxLength: 500 },
+      { id: 'portfolio', type: 'text', label: '포트폴리오 URL', required: false, placeholder: 'https://github.com/...' }
     ]
   },
   'tpl-2': {
@@ -49,9 +50,9 @@ const dummyTemplates = {
       { id: 'birthdate', type: 'date', label: '생년월일', required: true, placeholder: 'YYYY-MM-DD' },
       { id: 'phone', type: 'text', label: '번호', required: true, placeholder: '010-0000-0000' },
       { id: 'email', type: 'email', label: '이메일', required: true, placeholder: 'example@email.com' },
-      { id: 'intro', type: 'textarea', label: '간단 자기소개', required: true, placeholder: '자기소개를 입력하세요...', maxLength: 500 },
+      { id: 'shortBio', type: 'textarea', label: '간단 자기소개', required: true, placeholder: '자기소개를 입력하세요...', maxLength: 500 },
       { id: 'github', type: 'text', label: 'GitHub', required: false, placeholder: 'https://github.com/...' },
-      { id: 'blog', type: 'text', label: '기술 블로그', required: false, placeholder: 'https://...' },
+      { id: 'blog', type: 'text', label: '기술 블로그', required: false, placeholder: 'https://...' }
     ]
   },
   'tpl-3': {
@@ -64,29 +65,25 @@ const dummyTemplates = {
       { id: 'birthdate', type: 'date', label: '생년월일', required: true, placeholder: 'YYYY-MM-DD' },
       { id: 'phone', type: 'text', label: '번호', required: true, placeholder: '010-0000-0000' },
       { id: 'email', type: 'email', label: '이메일', required: true, placeholder: 'example@email.com' },
-      { id: 'intro', type: 'textarea', label: '간단 자기소개', required: true, placeholder: '자기소개를 입력하세요...', maxLength: 500 },
+      { id: 'shortBio', type: 'textarea', label: '간단 자기소개', required: true, placeholder: '자기소개를 입력하세요...', maxLength: 500 }
     ]
   }
 }
 
-// 더미 공고-템플릿 매핑
 const jobTemplateMap = {
   '1': 'tpl-1',
   '2': 'tpl-2',
   '3': 'tpl-1',
   '4': 'tpl-3',
-  '5': 'tpl-3',
+  '5': 'tpl-3'
 }
 
-// 템플릿 로드
 onMounted(() => {
-  // 실제로는 API 호출: GET /api/jobs/:jobId/template
   setTimeout(() => {
     const templateId = jobTemplateMap[jobId.value] || 'tpl-3'
     template.value = dummyTemplates[templateId]
 
-    // 폼 데이터 초기화
-    template.value.fields.forEach(field => {
+    template.value.fields.forEach((field) => {
       formData.value[field.id] = ''
     })
 
@@ -94,30 +91,63 @@ onMounted(() => {
   }, 300)
 })
 
-// 취소
 const handleCancel = () => {
   router.push(`/careers/${companySlug.value}`)
 }
 
-// 제출
-const handleSubmit = () => {
-  // 필수 필드 검증
-  const missingFields = template.value.fields
-    .filter(f => f.required && !formData.value[f.id])
-    .map(f => f.label)
+const extractSubmitErrorMessage = (error) => {
+  const response = error?.response
+  if (!response) {
+    return '백엔드 서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해 주세요.'
+  }
 
-  if (missingFields.length > 0) {
-    alert(`다음 필수 항목을 입력해주세요: ${missingFields.join(', ')}`)
+  return (
+    response?.data?.message ||
+    response?.data?.error?.message ||
+    response?.data?.errorMessage ||
+    `지원서 제출에 실패했습니다. (HTTP ${response.status})`
+  )
+}
+
+const buildApplicationPayload = () => {
+  return {
+    name: formData.value.name || '',
+    gender: formData.value.gender || '',
+    birthDate: formData.value.birthdate || '',
+    phone: formData.value.phone || '',
+    email: formData.value.email || '',
+    shortBio: formData.value.shortBio || '',
+    portfolioUrl: formData.value.portfolio || formData.value.github || formData.value.blog || ''
+  }
+}
+
+const handleSubmit = async () => {
+  if (submitting.value) {
     return
   }
 
-  // TODO: API 연동 - POST /api/applications
-  console.log('Submit:', formData.value)
-  alert('지원서가 제출되었습니다.')
-  router.push(`/careers/${companySlug.value}`)
+  const missingFields = template.value.fields
+    .filter((field) => field.required && !formData.value[field.id])
+    .map((field) => field.label)
+
+  if (missingFields.length > 0) {
+    alert(`다음 필수 항목을 입력해 주세요: ${missingFields.join(', ')}`)
+    return
+  }
+
+  submitting.value = true
+  try {
+    const payload = buildApplicationPayload()
+    await applicantApi.submitCareerApplication(companySlug.value, jobId.value, payload)
+    alert('지원서가 제출되었습니다.')
+    router.push(`/careers/${companySlug.value}`)
+  } catch (error) {
+    alert(extractSubmitErrorMessage(error))
+  } finally {
+    submitting.value = false
+  }
 }
 
-// textarea 글자수
 const getTextLength = (fieldId) => {
   return formData.value[fieldId]?.length || 0
 }
@@ -125,7 +155,6 @@ const getTextLength = (fieldId) => {
 
 <template>
   <div class="min-h-screen bg-gray-50">
-    <!-- 헤더 -->
     <header class="bg-white border-b border-gray-200">
       <div class="max-w-2xl mx-auto px-6 h-16 flex items-center justify-between">
         <button @click="handleCancel" class="flex items-center gap-2 text-gray-600 hover:text-gray-900">
@@ -143,16 +172,14 @@ const getTextLength = (fieldId) => {
       </div>
     </header>
 
-    <!-- 로딩 -->
     <div v-if="loading" class="max-w-2xl mx-auto px-6 py-12 text-center text-gray-500">
       로딩 중...
     </div>
 
-    <!-- 지원서 폼 -->
     <main v-else class="max-w-2xl mx-auto px-6 py-8">
       <div class="mb-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 flex items-start justify-between gap-4">
         <div class="text-sm">
-          중복 지원 관리를 위해 지원 전에 간단 로그인해주세요.
+          중복 지원 관리를 위해 지원 전에 간단 로그인해 주세요.
         </div>
         <button
           @click="router.push({ path: `/careers/${companySlug}/login`, query: { redirect: route.fullPath } })"
@@ -161,21 +188,18 @@ const getTextLength = (fieldId) => {
           로그인하기
         </button>
       </div>
-      <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
-        <!-- 제목 -->
-        <h1 class="text-2xl font-bold text-gray-900 mb-2">지원서 작성</h1>
-        <p class="text-gray-600 mb-8">아래 양식을 작성하고 지원서를 제출해 주세요.</p>
 
-        <!-- 폼 필드 -->
+      <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
+        <h1 class="text-2xl font-bold text-gray-900 mb-2">지원서 작성</h1>
+        <p class="text-gray-600 mb-8 font-semibold">아래 양식을 작성하고 지원서를 제출해 주세요.</p>
+
         <form @submit.prevent="handleSubmit" class="space-y-6">
           <div v-for="field in template.fields" :key="field.id">
-            <!-- 라벨 -->
-            <label class="block text-sm font-medium text-gray-700 mb-2">
+            <label class="block text-sm font-semibold text-gray-800 mb-2">
               {{ field.label }}
               <span v-if="field.required" class="text-red-500 ml-1">*</span>
             </label>
 
-            <!-- 텍스트 입력 -->
             <div v-if="field.type === 'text' || field.type === 'email'" class="relative">
               <span v-if="field.id === 'name'" class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
                 <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -196,11 +220,10 @@ const getTextLength = (fieldId) => {
                 v-model="formData[field.id]"
                 :type="field.type"
                 :placeholder="field.placeholder"
-                :class="['w-full py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500', field.id === 'name' || field.id === 'email' || field.id === 'phone' ? 'pl-10 pr-4' : 'px-4']"
+                :class="['w-full py-3 border border-gray-300 rounded-lg text-gray-800 placeholder:text-gray-400 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 font-semibold', field.id === 'name' || field.id === 'email' || field.id === 'phone' ? 'pl-10 pr-4' : 'px-4']"
               />
             </div>
 
-            <!-- 날짜 입력 -->
             <div v-else-if="field.type === 'date'" class="relative">
               <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
                 <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -211,11 +234,10 @@ const getTextLength = (fieldId) => {
                 v-model="formData[field.id]"
                 type="date"
                 :placeholder="field.placeholder"
-                class="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                class="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg text-gray-800 placeholder:text-gray-400 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 font-semibold"
               />
             </div>
 
-            <!-- 라디오 버튼 -->
             <div v-else-if="field.type === 'radio'" class="flex gap-6">
               <label
                 v-for="option in field.options"
@@ -229,35 +251,32 @@ const getTextLength = (fieldId) => {
                   v-model="formData[field.id]"
                   class="w-4 h-4 text-brand-600 border-gray-300 focus:ring-brand-500"
                 />
-                <span class="text-gray-700">{{ option }}</span>
+                <span class="text-gray-800 font-semibold">{{ option }}</span>
               </label>
             </div>
 
-            <!-- 텍스트영역 -->
             <div v-else-if="field.type === 'textarea'" class="relative">
               <textarea
                 v-model="formData[field.id]"
                 :placeholder="field.placeholder"
                 :maxlength="field.maxLength"
                 rows="4"
-                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 resize-none"
+                class="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-800 placeholder:text-gray-400 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 resize-none font-semibold"
               ></textarea>
               <span v-if="field.maxLength" class="absolute bottom-3 right-3 text-xs text-gray-400">
                 {{ getTextLength(field.id) }} / {{ field.maxLength }}
               </span>
             </div>
 
-            <!-- 파일 업로드 -->
             <div v-else-if="field.type === 'file'">
               <input
                 type="file"
                 :id="field.id"
-                class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                class="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-700 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
               />
             </div>
           </div>
 
-          <!-- 버튼 영역 -->
           <div class="flex items-center justify-end gap-3 pt-6 border-t border-gray-200">
             <button
               type="button"
@@ -268,14 +287,14 @@ const getTextLength = (fieldId) => {
             </button>
             <button
               type="submit"
-              class="px-6 py-2.5 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors font-medium"
+              :disabled="submitting"
+              class="px-6 py-2.5 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors font-semibold disabled:opacity-70 disabled:cursor-not-allowed"
             >
               지원서 제출
             </button>
           </div>
         </form>
 
-        <!-- 개인정보 동의 문구 -->
         <p class="text-sm text-gray-500 text-center mt-6">
           지원서를 제출하면 '<span class="text-brand-600 underline cursor-pointer">개인정보</span>' 처리방침에 동의하게 됩니다.
         </p>


### PR DESCRIPTION
## 💡 개요
> 지원자 관리 화면의 **엑셀 다운로드 버튼**을 클라이언트 내 XLSX 생성 방식에서 **백엔드 export API 호출 + 파일 저장(blob)** 방식으로 변경했습니다.  
> 필터(검색어/공고/상태) 조건을 다운로드 요청 파라미터로 함께 전달하고, 다운로드 중 중복 클릭 방지/오류 처리도 추가했습니다.

## 🔗 관련 이슈
Closes #

## 📝 작업 상세 내용
- [x] `src/api/applicant.js`에 지원자 엑셀 다운로드 API 메서드 추가 (`responseType: 'blob'`)
- [x] `ApplicantListView`의 엑셀 다운로드 로직을 API 호출 후 `blob` 파일 저장 방식으로 교체
- [x] 버튼 비활성화(`isExporting || loading`), 파일명 파싱(`Content-Disposition`), 다운로드 실패 alert 처리 추가

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 다운로드 API 경로/폴백 전략(`recruitment/applicants/export` → legacy/workspace fallback)이 팀 표준에 맞는지 확인 부탁드립니다.
> `Content-Disposition` 파일명 파싱 로직(UTF-8/일반 filename 처리) 검토 부탁드립니다.