### PR TITLE
fix : [FE] 회의실 예약 조회 및 스케줄러 미적용 에러 수정  (#143)

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,8 +9,10 @@ const api = axios.create({
 })
 
 let workspaceRefreshPromise = null
+let workspaceRefreshDisabled = false
 
 const refreshWorkspaceId = async () => {
+  if (workspaceRefreshDisabled) return null
   const token = localStorage.getItem('accessToken')
   if (!token) return null
 
@@ -23,7 +25,10 @@ const refreshWorkspaceId = async () => {
         }
       })
       .then((res) => res?.data?.data?.workspaceId || null)
-      .catch(() => null)
+      .catch(() => {
+        workspaceRefreshDisabled = true
+        return null
+      })
       .finally(() => {
         workspaceRefreshPromise = null
       })
@@ -67,11 +72,13 @@ api.interceptors.response.use(
       requestUrl.includes('/users/signup')
 
     const isWorkspaceDiscoveryRoute = requestUrl.includes('/users/me/workspace')
+    const isInterviewAvailabilityRoute = requestUrl.includes('/interviews/availability')
 
     if (
       status === 400 &&
       !isAuthRoute &&
       !isWorkspaceDiscoveryRoute &&
+      !isInterviewAvailabilityRoute &&
       !originalRequest._workspaceRetried &&
       localStorage.getItem('accessToken')
     ) {
@@ -84,7 +91,7 @@ api.interceptors.response.use(
       }
     }
 
-    if (status === 400 && !isAuthRoute && !isWorkspaceDiscoveryRoute) {
+    if (status === 400 && !isAuthRoute && !isWorkspaceDiscoveryRoute && !isInterviewAvailabilityRoute) {
       const message = String(error.response?.data?.error?.message || '')
       const workspaceContextError = /workspace|tenant|member/i.test(message)
 

--- a/src/views/MeetingRoomsView.vue
+++ b/src/views/MeetingRoomsView.vue
@@ -885,7 +885,6 @@ const openCreateRoom = () => {
       message="회의실 예약이 성공적으로 완료되었습니다."
       confirmText="확인"
       :showCancel="false"
-      @close="successModalOpen = false"
       @confirm="successModalOpen = false"
     />
 
@@ -908,7 +907,6 @@ const openCreateRoom = () => {
       :message="`'${updatedRoomName}' 회의실 정보가 수정되었습니다.`"
       confirmText="확인"
       :showCancel="false"
-      @close="roomUpdatedModalOpen = false"
       @confirm="roomUpdatedModalOpen = false"
     />
 
@@ -919,7 +917,6 @@ const openCreateRoom = () => {
       :message="`'${createdRoomName}' 회의실이 성공적으로 등록되었습니다.`"
       confirmText="확인"
       :showCancel="false"
-      @close="roomCreatedModalOpen = false"
       @confirm="roomCreatedModalOpen = false"
     />
 

--- a/src/views/interview/InterviewScheduleCreateView.vue
+++ b/src/views/interview/InterviewScheduleCreateView.vue
@@ -260,8 +260,11 @@ const loadAvailability = async () => {
   if (!weekDays.value.length) return
   const weekStart = new Date(toApiDateTime(weekDays.value[0].date))
   const now = new Date()
-  const fromBase = weekStart > now ? weekStart : now
-  const from = `${fromBase.getFullYear()}-${pad2(fromBase.getMonth() + 1)}-${pad2(fromBase.getDate())}T${pad2(fromBase.getHours())}:${pad2(fromBase.getMinutes())}:${pad2(fromBase.getSeconds())}`
+  const nowWithBuffer = new Date(now.getTime() + 60 * 1000)
+  const fromBase = weekStart > nowWithBuffer ? weekStart : nowWithBuffer
+  const normalizedFrom = new Date(fromBase)
+  normalizedFrom.setSeconds(0, 0)
+  const from = `${normalizedFrom.getFullYear()}-${pad2(normalizedFrom.getMonth() + 1)}-${pad2(normalizedFrom.getDate())}T${pad2(normalizedFrom.getHours())}:${pad2(normalizedFrom.getMinutes())}:00`
   const interviewerIds = interviewers.value.map((m) => Number(m.id)).filter((id) => Number.isFinite(id))
   const applicantIds = applicants.value.map((m) => Number(m.id)).filter((id) => Number.isFinite(id))
   const meetingRoomIds = rooms.value.map((room) => Number(room.id)).filter((id) => Number.isFinite(id))


### PR DESCRIPTION
## 💡 개요
회의실 예약 조회 및 스케줄러 미적용 에러 수정

## 🔗 관련 이슈
Closes #143 

## 📝 작업 상세 내용
- [x]  회의실 조회 에러 수정
- [x]   회의실 예약 에러 수정
- [x]  회의실 스케줄러 적용 에러 수정

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 워크스페이스 새로고침 실패 시 반복 재시도를 방지하는 에러 처리 개선
  * 인터뷰 가용성 요청에서 자동 재시도 로직 제외
  * 회의실 모달의 닫기 이벤트 처리 방식 조정
  * 인터뷰 일정 생성 시 시작 시간 계산 로직 개선 (버퍼 시간 추가)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->