### PR TITLE
feat(FE): 지원서 칸반 이동 알림 및 이메일 연동 (#155)

### DIFF
--- a/src/components/NotificationDropdown.vue
+++ b/src/components/NotificationDropdown.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { useNotificationStore, formatNotificationTimeAgo } from '@/stores/notification'
+import { useNotificationStore, formatNotificationTimeAgo, buildNotificationFallbackRoute, getNotificationVisualType } from '@/stores/notification'
 import { useAnnouncementNotificationModal } from '@/composables/useAnnouncementNotificationModal'
 import AnnouncementDetailModal from '@/components/announcement/AnnouncementDetailModal.vue'
 import { storeToRefs } from 'pinia'
@@ -25,18 +25,32 @@ const {
 const visibleCount = computed(() => dropdownNotifications.value.length)
 
 const getNotificationIconClass = (item) => {
-  if (item.filterType === 'ANNOUNCEMENT') {
+  const visualType = getNotificationVisualType(item)
+
+  if (visualType === 'announcement') {
     return 'bg-amber-50 text-amber-600 border border-amber-100'
   }
-  if (item.filterType === 'INTERVIEW') {
+  if (visualType === 'interview') {
     return 'bg-emerald-50 text-emerald-600 border border-emerald-100'
+  }
+  if (visualType === 'kanban') {
+    return 'bg-indigo-50 text-indigo-600 border border-indigo-100'
   }
   return 'bg-slate-100 text-slate-500 border border-slate-200'
 }
 
-const goToNotificationsPage = async () => {
+const navigateToNotificationTarget = async (item) => {
+  const target = item?.actionUrl || buildNotificationFallbackRoute(item)
+  const resolved = router.resolve(target)
+
   emit('close')
-  await router.push({ path: '/notifications', query: { tab: 'all' } })
+
+  if (resolved?.matched?.length) {
+    await router.push(target)
+    return
+  }
+
+  await router.push(buildNotificationFallbackRoute(item))
 }
 
 const handleNotificationClick = async (item) => {
@@ -48,7 +62,7 @@ const handleNotificationClick = async (item) => {
       return
     }
 
-    await goToNotificationsPage()
+    await navigateToNotificationTarget(item)
   } catch (error) {
     console.error('알림 읽음 처리 실패:', error)
     actionError.value = '알림을 열지 못했습니다. 잠시 후 다시 시도해 주세요.'
@@ -158,11 +172,14 @@ onBeforeUnmount(() => {
 
         <div class="flex gap-4">
           <div class="flex-shrink-0 w-12 h-12 rounded-xl flex items-center justify-center" :class="getNotificationIconClass(item)">
-            <svg v-if="item.filterType === 'ANNOUNCEMENT'" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg v-if="getNotificationVisualType(item) === 'announcement'" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882A1 1 0 0112.447 5l6.382 3.191A1 1 0 0119.382 9H20a1 1 0 110 2h-.618a1 1 0 01-.553.809L16 13.191V16a2 2 0 11-4 0v-.809l-2.829-1.382A1 1 0 018.618 13H8a1 1 0 110-2h.618a1 1 0 01.553-.809L11 8.809V5.882z" />
             </svg>
-            <svg v-else-if="item.filterType === 'INTERVIEW'" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg v-else-if="getNotificationVisualType(item) === 'interview'" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <svg v-else-if="getNotificationVisualType(item) === 'kanban'" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h7v12H4V6zm9 0h7v5h-7V6zm0 7h7v5h-7v-5z" />
             </svg>
             <svg v-else class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />

--- a/src/stores/notification.js
+++ b/src/stores/notification.js
@@ -65,6 +65,16 @@ export const buildNotificationFallbackRoute = (item) => {
   return '/notifications'
 }
 
+export const getNotificationVisualType = (item) => {
+  const type = String(item?.type || '').toUpperCase()
+  const filterType = String(item?.filterType || '').toUpperCase()
+
+  if (filterType === 'ANNOUNCEMENT') return 'announcement'
+  if (type === 'APPLICATION_PROCESS_CHANGED') return 'kanban'
+  if (filterType === 'INTERVIEW') return 'interview'
+  return 'system'
+}
+
 const normalizeNotification = (item = {}) => ({
   id: item.id,
   type: item.type || '',

--- a/src/views/NotificationView.vue
+++ b/src/views/NotificationView.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import {
   buildNotificationFallbackRoute,
   formatNotificationDateTime,
+  getNotificationVisualType,
   NOTIFICATION_FILTERS,
   useNotificationStore
 } from '@/stores/notification'
@@ -27,11 +28,16 @@ const {
 } = useAnnouncementNotificationModal()
 
 const getNotificationIconClass = (item) => {
-  if (item.filterType === 'ANNOUNCEMENT') {
+  const visualType = getNotificationVisualType(item)
+
+  if (visualType === 'announcement') {
     return 'bg-amber-50 text-amber-600'
   }
-  if (item.filterType === 'INTERVIEW') {
+  if (visualType === 'interview') {
     return 'bg-emerald-50 text-emerald-600'
+  }
+  if (visualType === 'kanban') {
+    return 'bg-indigo-50 text-indigo-600'
   }
   return 'bg-slate-100 text-slate-500'
 }
@@ -216,11 +222,14 @@ onBeforeUnmount(() => {
 
         <div class="w-10 h-10 rounded-full flex items-center justify-center shrink-0"
           :class="item.isRead ? getNotificationIconClass(item) : 'bg-blue-100 text-blue-600'">
-          <svg v-if="item.filterType === 'ANNOUNCEMENT'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg v-if="getNotificationVisualType(item) === 'announcement'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882A1 1 0 0112.447 5l6.382 3.191A1 1 0 0119.382 9H20a1 1 0 110 2h-.618a1 1 0 01-.553.809L16 13.191V16a2 2 0 11-4 0v-.809l-2.829-1.382A1 1 0 018.618 13H8a1 1 0 110-2h.618a1 1 0 01.553-.809L11 8.809V5.882z" />
           </svg>
-          <svg v-else-if="item.filterType === 'INTERVIEW'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg v-else-if="getNotificationVisualType(item) === 'interview'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+          </svg>
+          <svg v-else-if="getNotificationVisualType(item) === 'kanban'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h7v12H4V6zm9 0h7v5h-7V6zm0 7h7v5h-7v-5z" />
           </svg>
           <svg v-else class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />

--- a/src/views/RecruitmentDetailView.vue
+++ b/src/views/RecruitmentDetailView.vue
@@ -702,15 +702,37 @@ const resetAutomationForm = () => {
 }
 
 const startEditAutomationRule = (rule) => {
+  const normalizedPayload = normalizeAutomationRulePayload(rule?.payload)
+
   ruleModalProcessId.value = rule.recruitmentProcessId ?? ruleModalProcessId.value
   editingRuleId.value = rule.ruleId
   automationForm.value = {
     recruitmentProcessId: rule.recruitmentProcessId ?? '',
     triggerType: rule.triggerType ?? 'ON_ENTER',
     actionType: rule.actionType ?? 'EMAIL',
-    templateCode: rule.payload?.templateCode ?? ''
+    templateCode: normalizedPayload?.templateCode ?? ''
   }
 }
+
+const normalizeAutomationRulePayload = (payload) => {
+  if (!payload) return {}
+
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload)
+      return parsed && typeof parsed === 'object' ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return typeof payload === 'object' ? payload : {}
+}
+
+const normalizeAutomationRule = (rule) => ({
+  ...rule,
+  payload: normalizeAutomationRulePayload(rule?.payload)
+})
 
 const loadAutomationRules = async () => {
   if (!canMoveApplicants.value) return
@@ -721,7 +743,7 @@ const loadAutomationRules = async () => {
   try {
     const response = await automationRulesApi.getRecruitmentRules(jobId)
     const payload = automationRulesApi.extractResponseData(response)
-    automationRules.value = Array.isArray(payload) ? payload : []
+    automationRules.value = Array.isArray(payload) ? payload.map(normalizeAutomationRule) : []
     if (!editingRuleId.value) {
       resetAutomationForm()
     }


### PR DESCRIPTION
## 💡 개요
> 지원서 칸반 이동 시 알림 및 이메일을 연동합니다.

## 🔗 관련 이슈
Closes #155

## 📝 작업 상세 내용
- [ ] 지원서 칸반 이동 알림 뷰
- [ ] 지원서 칸반 룰 이메일 전송

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [ ] 커밋 메시지 컨벤션을 지켰나요?
- [ ] 로컬에서 테스트는 모두 통과했나요?
- [ ] 불필요한 공백이나 주석은 제거했나요?
- [ ] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 칸반 알림 유형 지원 추가로 다양한 알림 카테고리 확장

* **버그 수정**
  * 알림 시각 유형 처리 로직 개선으로 더 안정적인 아이콘 렌더링 보장
  * 자동화 규칙의 페이로드 정규화 처리 강화로 설정 데이터 일관성 확보

<!-- end of auto-generated comment: release notes by coderabbit.ai -->