### PR TITLE
feat(FE): 채용 홈 빈 상태 화면과 권한별 UI 흐름 개선 (#183)

### DIFF
--- a/src/views/RecruitmentView.vue
+++ b/src/views/RecruitmentView.vue
@@ -530,6 +530,27 @@ const confirmDelete = async () => {
     deleting.value = false
   }
 }
+
+const goToCreateRecruitment = () => {
+  if (!ensureHrRecruitmentAction('채용 공고 생성은 인사담당자만 가능합니다.')) {
+    return
+  }
+  router.push('/recruitment/create')
+}
+
+const goToEditRecruitment = (jobId) => {
+  if (!ensureHrRecruitmentAction('채용 공고 수정은 인사담당자만 가능합니다.')) {
+    return
+  }
+  router.push(`/recruitment/jobs/${jobId}/edit`)
+}
+
+const resetFilters = () => {
+  searchQuery.value = ''
+  statusFilter.value = '전체 상태'
+  sortBy.value = '최신순'
+}
+
 // --- 검색 및 필터링 로직 ---
 const searchQuery = ref('')
 const statusFilter = ref('전체 상태')
@@ -586,6 +607,41 @@ const filteredJobs = computed(() => {
   }
 
   return result
+})
+
+const isFilterApplied = computed(() => {
+  return Boolean(searchQuery.value.trim()) || statusFilter.value !== '전체 상태'
+})
+
+const showEmptyState = computed(() => !loading.value && filteredJobs.value.length === 0)
+
+const emptyState = computed(() => {
+  if (isFilterApplied.value) {
+    return {
+      title: '조건에 맞는 채용 공고가 없습니다.',
+      description: '검색어나 상태 필터를 다시 조정하면 다른 채용 공고를 확인할 수 있습니다.',
+      actionText: '필터 초기화',
+      action: resetFilters
+    }
+  }
+
+  if (canManageRecruitment.value) {
+    return {
+      title: '아직 등록된 채용 공고가 없습니다.',
+      description:
+        '첫 채용 공고를 등록하면 이 공간에서 공고 현황과 이번 주 면접 일정을 함께 관리할 수 있습니다.',
+      actionText: '새 공고 만들기',
+      action: goToCreateRecruitment
+    }
+  }
+
+  return {
+    title: '현재 확인할 수 있는 채용 공고가 없습니다.',
+    description:
+      '담당 조직, 참조 조직, 또는 등록된 면접관으로 연결된 채용 공고만 이 화면에 표시됩니다.',
+    actionText: '',
+    action: null
+  }
 })
 
 // --- 링크 복사 및 면접관 설정 기능 ---
@@ -833,6 +889,7 @@ const saveInterviewers = async () => {
 
     <div class="flex flex-col md:flex-row md:items-center justify-end gap-4 relative z-0">
       <button
+          v-if="canManageRecruitment"
           @click="goToCreateRecruitment"
           class="bg-brand-600 hover:bg-brand-700 text-white px-5 py-2.5 rounded-lg font-bold shadow-md hover:shadow-lg transition-all flex items-center justify-center group z-20"
       >
@@ -896,7 +953,27 @@ const saveInterviewers = async () => {
       </div>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+    <div v-if="showEmptyState"
+         class="bg-white border border-dashed border-slate-300 rounded-3xl px-8 py-16 text-center shadow-sm">
+      <div class="w-16 h-16 mx-auto mb-5 rounded-2xl bg-slate-100 text-slate-500 flex items-center justify-center">
+        <svg class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 17v-6m3 6V7m3 10v-3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+      </div>
+      <h3 class="text-xl font-bold text-slate-900 mb-2">{{ emptyState.title }}</h3>
+      <p class="text-sm text-slate-500 leading-relaxed max-w-xl mx-auto">
+        {{ emptyState.description }}
+      </p>
+      <button
+        v-if="emptyState.action"
+        @click="emptyState.action && emptyState.action()"
+        class="mt-6 inline-flex items-center justify-center px-5 py-2.5 rounded-xl bg-brand-600 text-white font-bold hover:bg-brand-700 shadow-sm transition-colors"
+      >
+        {{ emptyState.actionText }}
+      </button>
+    </div>
+
+    <div v-else class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
       <div v-for="job in filteredJobs" :key="job.id"
            class="group relative bg-white border border-slate-200 rounded-2xl p-6 hover:border-brand-300 hover:shadow-lg hover:-translate-y-1 transition-all duration-300 shadow-sm"
            :class="{'relative z-20 border-brand-300 ring-2 ring-brand-100': activeMenuId === job.id}">
@@ -1274,16 +1351,3 @@ const saveInterviewers = async () => {
 .custom-scrollbar::-webkit-scrollbar-thumb { background-color: #cbd5e1; border-radius: 20px; }
 .custom-scrollbar:hover::-webkit-scrollbar-thumb { background-color: #94a3b8; }
 </style>
-const goToCreateRecruitment = () => {
-  if (!ensureHrRecruitmentAction('채용 공고 생성은 인사담당자만 가능합니다.')) {
-    return
-  }
-  router.push('/recruitment/create')
-}
-
-const goToEditRecruitment = (jobId) => {
-  if (!ensureHrRecruitmentAction('채용 공고 수정은 인사담당자만 가능합니다.')) {
-    return
-  }
-  router.push(`/recruitment/jobs/${jobId}/edit`)
-}


### PR DESCRIPTION
## 💡 개요
채용 홈에서 사용자 권한에 따라 공고 목록과 화면 상태가 자연스럽게 보이도록 프론트를 정리하였으며, 접근 가능한 채용 공고가 없을 때는 흰 화면 대신 상황에 맞는 빈 상태 UI를 보여주고, 검색이나 필터 때문에 결과가 없는 경우에는 별도 안내와 초기화 액션을 제공한다.
또한 인사담당자만 새 공고 만들기 액션을 볼 수 있도록 권한별 UI도 함께 정리하였음.

## 🔗 관련 이슈
Closes #183

## 📝 작업 상세 내용
- [x] 채용 홈에서 공고 목록이 비어 있을 때 권한 상태와 필터 상태에 맞는 빈 상태 UI를 추가
- [x] 검색/필터 결과가 없는 경우와 실제 접근 가능한 공고가 없는 경우를 구분해 안내 문구와 액션 분리
- [x] 인사담당자 권한에 맞게 새 공고 만들기 버튼과 채용 홈 화면 흐름 정리

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 일자리가 없거나 필터가 적용되지 않은 경우 빈 상태 화면을 표시합니다.
  * 검색, 상태, 정렬 필터를 한 번에 초기화할 수 있는 기능이 추가되었습니다.
  * HR 관리자만 새 공고 생성 버튼을 볼 수 있도록 권한 기반 표시가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->