### PR TITLE
feat(FE): 대시보드 실데이터 연동 및 익명 라운지 UI 추가 (#185)

### DIFF
--- a/src/api/dashboardChat.js
+++ b/src/api/dashboardChat.js
@@ -1,0 +1,11 @@
+import api from '@/api'
+
+export const dashboardChatApi = {
+  getMessages() {
+    return api.get('/dashboard-chat/messages')
+  },
+
+  createMessage(payload) {
+    return api.post('/dashboard-chat/messages', payload)
+  }
+}

--- a/src/components/dashboard/DashboardChatPanel.vue
+++ b/src/components/dashboard/DashboardChatPanel.vue
@@ -1,0 +1,245 @@
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { dashboardChatApi } from '@/api/dashboardChat'
+import { useNotificationStore } from '@/stores/notification'
+
+const MAX_MESSAGES = 50
+const props = defineProps({
+  showCloseButton: {
+    type: Boolean,
+    default: false
+  }
+})
+const emit = defineEmits(['close'])
+
+const notificationStore = useNotificationStore()
+
+const loading = ref(false)
+const sending = ref(false)
+const errorMessage = ref('')
+const messageText = ref('')
+const messages = ref([])
+const bodyRef = ref(null)
+
+let removeStreamListener = () => {}
+
+const normalizedMessages = computed(() => messages.value.slice(-MAX_MESSAGES))
+const messageCountLabel = computed(() => `${normalizedMessages.value.length}/${MAX_MESSAGES}`)
+const canSend = computed(() => !sending.value && messageText.value.trim().length > 0)
+
+const normalizeMessage = (item = {}) => ({
+  id: Number(item.id || 0),
+  alias: String(item.alias || '익명'),
+  content: String(item.content || '').trim(),
+  createdAt: item.createdAt || null,
+  mine: Boolean(item.mine)
+})
+
+const formatMessageTime = (value) => {
+  if (!value) return ''
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+
+  return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
+}
+
+// 메시지 목록을 최신 50개 기준으로 유지한다.
+const setMessages = (items) => {
+  messages.value = items.slice(-MAX_MESSAGES)
+}
+
+// 같은 메시지는 갱신하고, 새 메시지는 뒤에 추가한다.
+const mergeMessage = (item) => {
+  if (!item?.id) return
+
+  const index = messages.value.findIndex((message) => message.id === item.id)
+  if (index === -1) {
+    setMessages([...messages.value, item])
+    return
+  }
+
+  const nextMessages = [...messages.value]
+  nextMessages[index] = { ...nextMessages[index], ...item, mine: nextMessages[index].mine || item.mine }
+  setMessages(nextMessages)
+}
+
+// 새 메시지가 보이도록 스크롤을 하단으로 이동한다.
+const scrollToBottom = async () => {
+  await nextTick()
+  const element = bodyRef.value
+  if (!element) return
+  element.scrollTop = element.scrollHeight
+}
+
+// 최근 채팅 메시지를 초기 로딩한다.
+const loadMessages = async () => {
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    const response = await dashboardChatApi.getMessages()
+    const data = Array.isArray(response?.data?.data) ? response.data.data : []
+    setMessages(data.map(normalizeMessage))
+    await scrollToBottom()
+  } catch (error) {
+    console.error('대시보드 채팅 조회 실패:', error)
+    errorMessage.value = '채팅을 불러오지 못했습니다.'
+  } finally {
+    loading.value = false
+  }
+}
+
+// 입력한 채팅 메시지를 전송한다.
+const sendMessage = async () => {
+  const content = messageText.value.trim()
+  if (!content || sending.value) return
+
+  sending.value = true
+  errorMessage.value = ''
+
+  try {
+    const response = await dashboardChatApi.createMessage({ content })
+    const message = normalizeMessage(response?.data?.data || {})
+    mergeMessage(message)
+    messageText.value = ''
+    await scrollToBottom()
+  } catch (error) {
+    console.error('대시보드 채팅 전송 실패:', error)
+    errorMessage.value = '메시지 전송에 실패했습니다.'
+  } finally {
+    sending.value = false
+  }
+}
+
+// 알림 SSE 스트림에서 채팅 메시지 이벤트만 반영한다.
+const handleStreamEvent = async (event) => {
+  if (event?.type !== 'workspace-chat-message-created') return
+
+  const message = normalizeMessage(event?.payload?.message || {})
+  if (!message.id) return
+
+  mergeMessage(message)
+  await scrollToBottom()
+}
+
+onMounted(async () => {
+  await loadMessages()
+  removeStreamListener = notificationStore.addStreamListener(handleStreamEvent)
+})
+
+onBeforeUnmount(() => {
+  removeStreamListener()
+})
+
+watch(
+  () => normalizedMessages.value.length,
+  async () => {
+    await scrollToBottom()
+  }
+)
+</script>
+
+<template>
+  <section class="bg-white border border-slate-200 rounded-2xl p-5 shadow-sm h-[420px] max-h-[420px] flex flex-col">
+    <div class="flex items-start justify-between gap-4 mb-4">
+      <div>
+        <h3 class="text-base font-bold text-slate-800">익명 라운지</h3>
+        <p class="text-xs text-slate-400 mt-1">같은 워크스페이스 사람들과 가볍게 이야기할 수 있어요.</p>
+      </div>
+      <div class="flex items-center gap-2 shrink-0">
+        <span class="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-bold text-slate-500">
+          최근 {{ messageCountLabel }}
+        </span>
+        <button
+          v-if="props.showCloseButton"
+          type="button"
+          class="w-8 h-8 inline-flex items-center justify-center rounded-full border border-slate-200 bg-white text-slate-400 hover:text-slate-600 hover:border-slate-300 transition"
+          @click="emit('close')"
+        >
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div
+      ref="bodyRef"
+      class="min-h-0 flex-1 overflow-y-auto custom-scrollbar rounded-xl border border-slate-100 bg-slate-50/70 px-3 py-3 space-y-2"
+    >
+      <div v-if="loading" class="h-full flex flex-col items-center justify-center text-slate-300 min-h-[90px]">
+        <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-brand-600 mb-2"></div>
+        <p class="text-xs font-medium text-slate-400">채팅을 불러오는 중입니다.</p>
+      </div>
+
+      <div v-else-if="normalizedMessages.length === 0" class="h-full flex flex-col items-center justify-center text-slate-300 min-h-[90px]">
+        <svg class="w-9 h-9 mb-2 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4z" />
+        </svg>
+        <p class="text-xs font-medium">첫 메시지를 남겨보세요.</p>
+      </div>
+
+      <div
+        v-for="message in normalizedMessages"
+        :key="message.id"
+        class="flex"
+        :class="message.mine ? 'justify-end' : 'justify-start'"
+      >
+        <article
+          class="max-w-[85%] rounded-2xl px-3 py-2 shadow-sm"
+          :class="message.mine ? 'bg-brand-600 text-white' : 'bg-white border border-slate-200 text-slate-700'"
+        >
+          <div class="flex items-center gap-2 mb-1">
+            <span
+              class="text-[11px] font-bold"
+              :class="message.mine ? 'text-brand-50/90' : 'text-brand-700'"
+            >
+              {{ message.alias }}
+            </span>
+            <span
+              class="text-[10px]"
+              :class="message.mine ? 'text-white/70' : 'text-slate-400'"
+            >
+              {{ formatMessageTime(message.createdAt) }}
+            </span>
+          </div>
+          <p class="text-xs leading-5 whitespace-pre-wrap break-words">{{ message.content }}</p>
+        </article>
+      </div>
+    </div>
+
+    <div class="mt-4">
+      <div class="flex items-end gap-3">
+        <textarea
+          v-model="messageText"
+          rows="2"
+          maxlength="500"
+          class="flex-1 resize-none rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-brand-400 focus:ring-4 focus:ring-brand-100"
+          placeholder="익명으로 메시지를 남겨보세요."
+          @keydown.enter.exact.prevent="sendMessage"
+        />
+        <button
+          type="button"
+          class="shrink-0 rounded-xl bg-slate-900 px-4 py-2.5 text-sm font-bold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+          :disabled="!canSend"
+          @click="sendMessage"
+        >
+          {{ sending ? '전송 중' : '보내기' }}
+        </button>
+      </div>
+      <div class="mt-2 flex items-center justify-between gap-3">
+        <p v-if="errorMessage" class="text-xs font-medium text-rose-500">{{ errorMessage }}</p>
+        <p v-else class="text-xs text-slate-400">Enter로 바로 전송하고, Shift+Enter로 줄바꿈할 수 있어요.</p>
+        <p class="text-[11px] font-medium text-slate-400">{{ messageText.length }}/500</p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.custom-scrollbar::-webkit-scrollbar { width: 4px; }
+.custom-scrollbar::-webkit-scrollbar-track { background: transparent; }
+.custom-scrollbar::-webkit-scrollbar-thumb { background-color: #cbd5e1; border-radius: 20px; }
+.custom-scrollbar:hover::-webkit-scrollbar-thumb { background-color: #94a3b8; }
+</style>

--- a/src/stores/notification.js
+++ b/src/stores/notification.js
@@ -150,6 +150,7 @@ export const useNotificationStore = defineStore('notification', () => {
   const isNotificationPageActive = ref(false)
   const isStreamConnected = ref(false)
   const realtimeToast = ref(null)
+  const streamListeners = new Set()
 
   let streamAbortController = null
   let streamReconnectTimer = null
@@ -283,18 +284,34 @@ export const useNotificationStore = defineStore('notification', () => {
   }
 
   const handleStreamEvent = async (event) => {
+    let payload = null
+
+    if (event.data) {
+      try {
+        payload = JSON.parse(event.data)
+      } catch {
+        payload = null
+      }
+    }
+
+    const normalizedEvent = {
+      ...event,
+      payload
+    }
+
+    streamListeners.forEach((listener) => {
+      try {
+        listener(normalizedEvent)
+      } catch (error) {
+        console.error('SSE 리스너 실행 실패:', error)
+      }
+    })
+
     if (event.type === 'heartbeat' || event.type === 'connected') return
     if (event.type !== 'notification-created') return
 
     try {
-      let notificationId = null
-
-      try {
-        const parsed = JSON.parse(event.data || '{}')
-        notificationId = parsed?.notificationId ?? null
-      } catch {
-        notificationId = null
-      }
+      const notificationId = payload?.notificationId ?? null
 
       await refreshVisibleData()
 
@@ -409,6 +426,17 @@ export const useNotificationStore = defineStore('notification', () => {
     isNotificationPageActive.value = Boolean(value)
   }
 
+  const addStreamListener = (listener) => {
+    if (typeof listener !== 'function') {
+      return () => {}
+    }
+
+    streamListeners.add(listener)
+    return () => {
+      streamListeners.delete(listener)
+    }
+  }
+
   const syncReadState = (id) => {
     notifications.value = notifications.value.map((item) =>
       item.id === id ? { ...item, isRead: true, readAt: item.readAt || new Date().toISOString() } : item
@@ -501,6 +529,7 @@ export const useNotificationStore = defineStore('notification', () => {
     initialize,
     startNotificationStream,
     stopNotificationStream,
+    addStreamListener,
     setDropdownOpen,
     setNotificationPageActive,
     dismissRealtimeToast,

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,23 +1,297 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { storeToRefs } from 'pinia'
 import ScheduleDetailModal from '@/components/schedule/ScheduleDetailModal.vue'
+import InterviewDetailModal from '@/components/recruitment/InterviewDetailModal.vue'
 import AnnouncementModal from '@/components/announcement/AnnouncementModal.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
+import DashboardChatPanel from '@/components/dashboard/DashboardChatPanel.vue'
 import { announcementBoardApi } from '@/api/announcementBoard'
 import { memberApi } from '@/api/member'
+import { recruitmentApi } from '@/api/recruitment'
 import { useAuth } from '@/composables/useAuth'
+import { useScheduleStore } from '@/stores/schedule'
 
+const router = useRouter()
 const { user } = useAuth()
+const scheduleStore = useScheduleStore()
+const { schedules: allSchedules, loading: schedulesLoading } = storeToRefs(scheduleStore)
+
 const memberType = ref('')
+const recruitments = ref([])
+const weeklyInterviewSchedules = ref([])
 
 const showAnnouncementModal = ref(false)
-const announcementMode = ref('list') // list | create | detail
+const announcementMode = ref('list')
 const selectedAnnouncementId = ref(null)
 const feedbackModal = ref({
   show: false,
   type: 'info',
   title: '',
   message: ''
+})
+
+const currentDate = ref(new Date())
+const selectedDate = ref(scheduleStore.getToday())
+
+const currentPage = ref(1)
+const pageSize = 3
+const announcements = ref([])
+
+const isDetailModalOpen = ref(false)
+const modalEvent = ref(null)
+const showInterviewDetailModal = ref(false)
+const selectedInterview = ref(null)
+const showDashboardChat = ref(false)
+
+const userName = computed(() => user.value?.name || '사용자')
+const currentUserId = computed(() => toPositiveNumber(user.value?.id))
+const currentUserName = computed(() => String(user.value?.name || '').trim())
+const isHrMember = computed(() => memberType.value === 'HR')
+const isInterviewer = computed(() => memberType.value === 'INTERVIEWER')
+const userRole = computed(() => {
+  if (isHrMember.value) return '인사담당자'
+  if (isInterviewer.value) return '면접관'
+  return '멤버'
+})
+
+const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토']
+
+const formatDateKey = (date) => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const formatDateLabel = (value = new Date()) => {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const yyyy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  return `${yyyy}.${mm}.${dd}`
+}
+
+const formatMonthDayLabel = (dateText) => {
+  const date = new Date(`${dateText}T00:00:00`)
+  if (Number.isNaN(date.getTime())) return ''
+  return `${date.getMonth() + 1}월 ${date.getDate()}일 ${daysOfWeek[date.getDay()]}요일`
+}
+
+const startOfWeek = (date) => {
+  const next = new Date(date)
+  next.setHours(0, 0, 0, 0)
+  next.setDate(next.getDate() - next.getDay())
+  return next
+}
+
+const endOfWeek = (date) => {
+  const next = startOfWeek(date)
+  next.setDate(next.getDate() + 6)
+  return next
+}
+
+const getDashboardRange = (baseDate) => {
+  const start = startOfWeek(baseDate)
+  const end = new Date(baseDate)
+  end.setHours(0, 0, 0, 0)
+  end.setDate(end.getDate() + 21)
+  return {
+    startDate: formatDateKey(start),
+    endDate: formatDateKey(end)
+  }
+}
+
+const toPositiveNumber = (value) => {
+  const number = Number(value)
+  return Number.isFinite(number) && number > 0 ? number : null
+}
+
+const normalizeDisplayName = (value) => {
+  const text = String(value || '').trim()
+  if (!text || text === '?' || text === '알 수 없음') return ''
+  return text
+}
+
+const splitNames = (value) => {
+  return String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+const getUniqueNames = (values) => {
+  return values
+    .map((value) => normalizeDisplayName(value))
+    .filter((name, index, names) => name && names.indexOf(name) === index)
+}
+
+const isCurrentUserInterviewer = (item, interviewerNames) => {
+  const interviewerUserId = toPositiveNumber(item?.interviewerUserId)
+  if (currentUserId.value && interviewerUserId && currentUserId.value === interviewerUserId) {
+    return true
+  }
+
+  if (!currentUserName.value) return false
+  return interviewerNames.includes(currentUserName.value)
+}
+
+const getDisplayStatus = (status, endDate) => {
+  const normalizedStatus = String(status || '').toUpperCase()
+  if (normalizedStatus === 'CLOSED') return 'closed'
+  if (normalizedStatus === 'DRAFT') return 'draft'
+
+  if (normalizedStatus === 'OPEN' && endDate) {
+    const now = new Date()
+    const end = new Date(endDate)
+    const diffDays = Math.ceil((end - now) / (1000 * 60 * 60 * 24))
+    if (diffDays <= 3) return 'urgent'
+    return 'open'
+  }
+
+  return normalizedStatus.toLowerCase() || 'draft'
+}
+
+const formatScheduleSummary = (schedule) => {
+  const attendees = Array.isArray(schedule?.attendees) ? schedule.attendees.filter(Boolean) : []
+  if (schedule?.applicantName && attendees.length > 0) {
+    return `${attendees[0]} · ${schedule.applicantName}`
+  }
+  if (schedule?.applicantName) return schedule.applicantName
+  if (attendees.length > 0) return attendees.join(', ')
+  return schedule?.description || '세부 정보 없음'
+}
+
+const normalizeWeeklySchedule = (item) => {
+  const start = item?.startAt ? new Date(item.startAt) : null
+  if (!(start instanceof Date) || Number.isNaN(start.getTime())) return null
+
+  const end = item?.endAt ? new Date(item.endAt) : new Date(start.getTime())
+  const interviewerNames = getUniqueNames(splitNames(item?.interviewerName))
+  const applicantNames = getUniqueNames(splitNames(item?.applicantName))
+  const showSelf = isCurrentUserInterviewer(item, interviewerNames)
+  const attendees = getUniqueNames([
+    ...interviewerNames.filter((name) => !showSelf || name !== currentUserName.value),
+    ...applicantNames
+  ])
+  const locationParts = [String(item?.location || '').trim(), String(item?.description || '').trim()]
+    .filter(Boolean)
+  const startTime = `${String(start.getHours()).padStart(2, '0')}:${String(start.getMinutes()).padStart(2, '0')}`
+  const endTime = `${String(end.getHours()).padStart(2, '0')}:${String(end.getMinutes()).padStart(2, '0')}`
+
+  return {
+    id: Number(item.id),
+    recruitmentId: toPositiveNumber(item?.recruitmentId),
+    title: String(item?.title || '').trim() || '면접 일정',
+    applicantName: String(item?.applicantName || '').trim(),
+    interviewerName: String(item?.interviewerName || '').trim(),
+    date: formatDateKey(start),
+    startTime,
+    endTime,
+    time: `${startTime} - ${endTime}`,
+    location: locationParts.join(' · '),
+    description: String(item?.description || '').trim(),
+    showSelf,
+    attendees
+  }
+}
+
+const currentYearMonth = computed(() => {
+  const y = currentDate.value.getFullYear()
+  const m = currentDate.value.getMonth() + 1
+  return `${y}년 ${m}월`
+})
+
+const currentWeek = computed(() => {
+  const base = startOfWeek(currentDate.value)
+
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = new Date(base)
+    date.setDate(base.getDate() + index)
+    const fullDate = formatDateKey(date)
+
+    return {
+      dateObj: date,
+      dateNum: date.getDate(),
+      dayName: daysOfWeek[index],
+      fullDate,
+      isToday: fullDate === scheduleStore.getToday(),
+      isSelected: fullDate === selectedDate.value
+    }
+  })
+})
+
+const selectedDateDisplay = computed(() => formatMonthDayLabel(selectedDate.value))
+
+const sortedSchedules = computed(() => {
+  return [...allSchedules.value].sort((a, b) => {
+    return `${a.date}${a.startTime}`.localeCompare(`${b.date}${b.startTime}`)
+  })
+})
+
+const todaySchedules = computed(() => {
+  const today = scheduleStore.getToday()
+  return sortedSchedules.value.filter((schedule) => schedule.date === today)
+})
+
+const selectedSchedules = computed(() => {
+  return sortedSchedules.value.filter((schedule) => schedule.date === selectedDate.value)
+})
+
+const upcomingSchedules = computed(() => {
+  const today = scheduleStore.getToday()
+  const now = new Date()
+  const currentTime = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
+
+  return sortedSchedules.value
+    .filter((schedule) => {
+      if (schedule.date > today) return true
+      if (schedule.date < today) return false
+      return schedule.endTime >= currentTime
+    })
+    .slice(0, 4)
+})
+
+const weeklyInterviewItems = computed(() => weeklyInterviewSchedules.value.slice(0, 4))
+
+const activeRecruitmentsCount = computed(() => {
+  return recruitments.value.filter((job) => String(job.status || '').toUpperCase() === 'OPEN').length
+})
+
+const urgentRecruitmentsCount = computed(() => {
+  return recruitments.value.filter((job) => getDisplayStatus(job.status, job.endDate) === 'urgent').length
+})
+
+const stats = computed(() => {
+  if (isHrMember.value) {
+    return [
+      { label: '오늘의 일정', value: todaySchedules.value.length, unit: '개', icon: 'calendar', color: 'text-orange-500 bg-orange-50' },
+      { label: '진행 중 공고', value: activeRecruitmentsCount.value, unit: '개', icon: 'briefcase', color: 'text-brand-600 bg-brand-50' },
+      { label: '이번 주 면접', value: weeklyInterviewSchedules.value.length, unit: '건', icon: 'users', color: 'text-emerald-600 bg-emerald-50' }
+    ]
+  }
+
+  return [
+    { label: '오늘의 일정', value: todaySchedules.value.length, unit: '개', icon: 'calendar', color: 'text-orange-500 bg-orange-50' },
+    { label: '다가오는 일정', value: upcomingSchedules.value.length, unit: '개', icon: 'calendar-stack', color: 'text-brand-600 bg-brand-50' },
+    { label: '이번 주 면접', value: weeklyInterviewSchedules.value.length, unit: '건', icon: 'users', color: 'text-emerald-600 bg-emerald-50' }
+  ]
+})
+
+const totalPages = computed(() => Math.max(1, Math.ceil(sortedAnnouncements.value.length / pageSize)))
+
+const sortedAnnouncements = computed(() => {
+  return [...announcements.value].sort((a, b) => {
+    if (a.pinned === b.pinned) return b.id - a.id
+    return a.pinned ? -1 : 1
+  })
+})
+
+const pagedAnnouncements = computed(() => {
+  const start = (currentPage.value - 1) * pageSize
+  return sortedAnnouncements.value.slice(start, start + pageSize)
 })
 
 const showAnnouncementForbiddenModal = () => {
@@ -30,19 +304,11 @@ const showAnnouncementForbiddenModal = () => {
 }
 
 const openFeedbackModal = ({ type = 'info', title = '안내', message = '' }) => {
-  feedbackModal.value = {
-    show: true,
-    type,
-    title,
-    message
-  }
+  feedbackModal.value = { show: true, type, title, message }
 }
 
 const ensureHrAnnouncementAccess = (message) => {
-  if (memberType.value === 'HR') {
-    return true
-  }
-
+  if (isHrMember.value) return true
   openFeedbackModal({
     type: 'warning',
     title: '권한 없음',
@@ -51,7 +317,6 @@ const ensureHrAnnouncementAccess = (message) => {
   return false
 }
 
-// 만들기
 const openCreateAnnouncement = () => {
   if (!ensureHrAnnouncementAccess('공지사항 생성은 인사담당자만 가능합니다.')) return
   announcementMode.value = 'create'
@@ -59,113 +324,16 @@ const openCreateAnnouncement = () => {
   showAnnouncementModal.value = true
 }
 
-// 상세보기
 const openAnnouncementDetail = (id) => {
   announcementMode.value = 'detail'
   selectedAnnouncementId.value = id
   showAnnouncementModal.value = true
 }
 
-// 닫기
 const closeAnnouncement = () => {
   showAnnouncementModal.value = false
   announcementMode.value = 'list'
   selectedAnnouncementId.value = null
-}
-
-// --- Data: User & Stats ---
-const userName = computed(() => user.value?.name || '사용자')
-const userRole = computed(() => {
-  if (memberType.value === 'HR') return '인사담당자'
-  if (memberType.value === 'INTERVIEWER') return '면접관'
-  return '멤버'
-})
-const stats = [
-  { label: '오늘의 일정', value: 3, icon: 'calendar', color: 'text-orange-500 bg-orange-50' },
-  { label: '진행 중 공고', value: 5, icon: 'briefcase', color: 'text-brand-600 bg-brand-50' },
-  { label: '신규 지원자', value: 12, icon: 'user-add', color: 'text-emerald-600 bg-emerald-50' },
-]
-
-// --- Data: Schedule ---
-const currentDate = ref(new Date())
-const selectedDate = ref(new Date())
-
-// Dummy Schedule Data
-const schedules = ref([
-  {
-    id: 1,
-    title: '직무 화상 인터뷰',
-    position: '퍼포먼스 마케터',
-    candidate: '최나루',
-    time: '09:00 - 10:00',
-    date: new Date().toISOString().split('T')[0], // Today
-    type: 'interview',
-    status: 'scheduled'
-  },
-  {
-    id: 2,
-    title: '컬쳐핏 인터뷰',
-    position: 'FE 주니어',
-    candidate: '김유리',
-    time: '13:00 - 14:00',
-    date: new Date().toISOString().split('T')[0],
-    type: 'interview',
-    status: 'scheduled'
-  },
-  {
-    id: 3,
-    title: '팀 회식',
-    position: '전체',
-    candidate: '-',
-    time: '18:00 - 20:00',
-    date: new Date().toISOString().split('T')[0],
-    type: 'meeting',
-    status: 'scheduled'
-  }
-])
-
-// --- Announcement Pagination ---
-const currentPage = ref(1)
-const pageSize = 5 // 한 페이지에 5개씩
-
-const totalPages = computed(() => {
-  return Math.ceil(sortedAnnouncements.value.length / pageSize)
-})
-
-const sortedAnnouncements = computed(() => {
-  return [...announcements.value].sort((a, b) => {
-    if (a.pinned === b.pinned) return b.id - a.id
-    return a.pinned ? -1 : 1
-  })
-})
-
-const pagedAnnouncements = computed(() => {
-  const start = (currentPage.value - 1) * pageSize
-  const end = start + pageSize
-  return sortedAnnouncements.value.slice(start, end)
-})
-
-const prevPage = () => {
-  if (currentPage.value > 1) {
-    currentPage.value--
-  }
-}
-
-const nextPage = () => {
-  if (currentPage.value < totalPages.value) {
-    currentPage.value++
-  }
-}
-
-
-// --- Data: Announcements ---
-const announcements = ref([])
-
-const formatDateLabel = (date = new Date()) => {
-  const yyyy = date.getFullYear()
-  const mm = String(date.getMonth() + 1).padStart(2, '0')
-  const dd = String(date.getDate()).padStart(2, '0')
-  return `${yyyy}.${mm}.${dd}`
 }
 
 const toViewAnnouncement = (item) => ({
@@ -175,26 +343,123 @@ const toViewAnnouncement = (item) => ({
   pinned: item.pinned,
   author: '관리자',
   tag: item.pinned ? '고정' : '',
-  date: formatDateLabel()
+  date: formatDateLabel(item.createdAt || new Date())
 })
 
 const loadAnnouncements = async () => {
   try {
     const response = await announcementBoardApi.list()
     const data = response?.data?.data
-    if (Array.isArray(data)) {
-      announcements.value = data.map((item) => toViewAnnouncement(item))
-      currentPage.value = 1
-    }
+    announcements.value = Array.isArray(data) ? data.map(toViewAnnouncement) : []
+    currentPage.value = 1
   } catch (error) {
     console.error('공지사항 조회 실패:', error)
+    announcements.value = []
   }
 }
 
-const handleSaveAnnouncement = async (data) => {
-  if (!ensureHrAnnouncementAccess('공지사항 생성은 인사담당자만 가능합니다.')) {
-    return
+const loadMemberType = async () => {
+  try {
+    const response = await memberApi.getMyMember()
+    memberType.value = response?.data?.data?.memberType || ''
+  } catch (_) {
+    memberType.value = ''
   }
+}
+
+const loadRecruitments = async () => {
+  try {
+    const response = await recruitmentApi.getRecruitments({ page: 0, size: 100 })
+    recruitments.value = Array.isArray(response?.data?.data) ? response.data.data : []
+  } catch (error) {
+    console.error('대시보드 채용 공고 조회 실패:', error)
+    recruitments.value = []
+  }
+}
+
+const loadWeeklyInterviewSchedules = async () => {
+  try {
+    const response = await recruitmentApi.getWeeklyInterviewSchedules(scheduleStore.getToday())
+    const data = response?.data?.data || []
+    weeklyInterviewSchedules.value = Array.isArray(data)
+      ? data.map(normalizeWeeklySchedule).filter(Boolean)
+      : []
+  } catch (error) {
+    console.error('대시보드 주간 면접 일정 조회 실패:', error)
+    weeklyInterviewSchedules.value = []
+  }
+}
+
+const loadSchedules = async () => {
+  const { startDate, endDate } = getDashboardRange(currentDate.value)
+  await scheduleStore.fetchSchedules(startDate, endDate)
+}
+
+const prevPage = () => {
+  if (currentPage.value > 1) currentPage.value -= 1
+}
+
+const nextPage = () => {
+  if (currentPage.value < totalPages.value) currentPage.value += 1
+}
+
+const prevWeek = () => {
+  const next = new Date(currentDate.value)
+  next.setDate(next.getDate() - 7)
+  currentDate.value = next
+  selectedDate.value = formatDateKey(next)
+}
+
+const nextWeek = () => {
+  const next = new Date(currentDate.value)
+  next.setDate(next.getDate() + 7)
+  currentDate.value = next
+  selectedDate.value = formatDateKey(next)
+}
+
+const goToday = () => {
+  const now = new Date()
+  currentDate.value = now
+  selectedDate.value = formatDateKey(now)
+}
+
+const selectDate = (dateObj) => {
+  const next = new Date(dateObj)
+  currentDate.value = next
+  selectedDate.value = formatDateKey(next)
+}
+
+const openScheduleDetail = async (schedule) => {
+  try {
+    const detail = await scheduleStore.getScheduleDetail(schedule.id)
+    modalEvent.value = detail || schedule
+  } catch (error) {
+    console.error('일정 상세 조회 실패:', error)
+    modalEvent.value = schedule
+  }
+  isDetailModalOpen.value = true
+}
+
+const openInterviewDetail = (schedule) => {
+  selectedInterview.value = schedule
+  showInterviewDetailModal.value = true
+}
+
+const goToRecruitmentHome = () => {
+  router.push('/recruitment/home')
+}
+
+const toggleDashboardChat = () => {
+  showDashboardChat.value = !showDashboardChat.value
+}
+
+const closeDashboardChat = () => {
+  showDashboardChat.value = false
+}
+
+const handleSaveAnnouncement = async (data) => {
+  if (!ensureHrAnnouncementAccess('공지사항 생성은 인사담당자만 가능합니다.')) return
+
   try {
     const response = await announcementBoardApi.create({
       title: data.title,
@@ -203,6 +468,7 @@ const handleSaveAnnouncement = async (data) => {
     })
     const created = response?.data?.data
     if (!created?.id) return
+
     announcements.value.unshift(toViewAnnouncement(created))
     currentPage.value = 1
     closeAnnouncement()
@@ -222,25 +488,26 @@ const handleSaveAnnouncement = async (data) => {
 }
 
 const handleUpdateAnnouncement = async (data) => {
-  if (!ensureHrAnnouncementAccess('공지사항 수정은 인사담당자만 가능합니다.')) {
-    return
-  }
+  if (!ensureHrAnnouncementAccess('공지사항 수정은 인사담당자만 가능합니다.')) return
+
   try {
     await announcementBoardApi.update(data.id, {
       title: data.title,
       content: data.content,
       pinned: data.pinned
     })
-    const idx = announcements.value.findIndex((a) => a.id === data.id)
-    if (idx !== -1) {
-      announcements.value[idx] = {
-        ...announcements.value[idx],
+
+    const index = announcements.value.findIndex((item) => item.id === data.id)
+    if (index !== -1) {
+      announcements.value[index] = {
+        ...announcements.value[index],
         title: data.title,
         content: data.content,
         pinned: data.pinned,
         tag: data.pinned ? '고정' : ''
       }
     }
+
     closeAnnouncement()
     openFeedbackModal({
       type: 'success',
@@ -258,12 +525,11 @@ const handleUpdateAnnouncement = async (data) => {
 }
 
 const handleRemoveAnnouncement = async (id) => {
-  if (!ensureHrAnnouncementAccess('공지사항 삭제는 인사담당자만 가능합니다.')) {
-    return
-  }
+  if (!ensureHrAnnouncementAccess('공지사항 삭제는 인사담당자만 가능합니다.')) return
+
   try {
     await announcementBoardApi.remove(id)
-    announcements.value = announcements.value.filter((a) => a.id !== id)
+    announcements.value = announcements.value.filter((item) => item.id !== id)
     if (currentPage.value > totalPages.value) {
       currentPage.value = Math.max(totalPages.value, 1)
     }
@@ -283,86 +549,23 @@ const handleRemoveAnnouncement = async (id) => {
   }
 }
 
-
-// --- Calendar Logic ---
-const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토']
-
-const currentYearMonth = computed(() => {
-  const y = currentDate.value.getFullYear()
-  const m = currentDate.value.getMonth() + 1
-  return `${y}년 ${m}월`
+watch(currentDate, async () => {
+  await loadSchedules()
 })
-
-const currentWeek = computed(() => {
-  const curr = new Date(currentDate.value)
-  const day = curr.getDay()
-  const diff = curr.getDate() - day
-  const startOfWeek = new Date(curr.setDate(diff))
-
-  const week = []
-  for (let i = 0; i < 7; i++) {
-    const d = new Date(startOfWeek)
-    d.setDate(startOfWeek.getDate() + i)
-    week.push({
-      dateObj: d,
-      dateNum: d.getDate(),
-      dayName: daysOfWeek[i],
-      fullDate: d.toISOString().split('T')[0],
-      isToday: d.toDateString() === new Date().toDateString(),
-      isSelected: d.toDateString() === selectedDate.value.toDateString()
-    })
-  }
-  return week
-})
-
-const selectedDateDisplay = computed(() => {
-  const d = selectedDate.value
-  const m = d.getMonth() + 1
-  const date = d.getDate()
-  const day = daysOfWeek[d.getDay()]
-  return `${m}월 ${date}일 ${day}요일`
-})
-
-const selectedSchedules = computed(() => {
-  const target = selectedDate.value.toISOString().split('T')[0]
-  return schedules.value.filter(s => s.date === target)
-})
-
-const prevWeek = () => { currentDate.value = new Date(currentDate.value.setDate(currentDate.value.getDate() - 7)) }
-const nextWeek = () => { currentDate.value = new Date(currentDate.value.setDate(currentDate.value.getDate() + 7)) }
-const goToday = () => {
-  const now = new Date()
-  currentDate.value = now
-  selectedDate.value = now
-}
-const selectDate = (dateObj) => { selectedDate.value = dateObj }
-
-// --- Modal Logic ---
-const isDetailModalOpen = ref(false)
-const modalEvent = ref(null)
-
-const openScheduleDetail = (schedule) => {
-  modalEvent.value = { ...schedule, description: `${schedule.position} / ${schedule.candidate}` }
-  isDetailModalOpen.value = true
-
-
-}
 
 onMounted(async () => {
-  loadAnnouncements()
-  try {
-    const response = await memberApi.getMyMember()
-    memberType.value = response?.data?.data?.memberType || ''
-  } catch (e) {
-    // 멤버 정보 조회 실패 시 기본값 유지
-  }
+  await Promise.all([
+    loadMemberType(),
+    loadAnnouncements(),
+    loadRecruitments(),
+    loadWeeklyInterviewSchedules(),
+    loadSchedules()
+  ])
 })
 </script>
 
 <template>
   <div class="min-h-full space-y-6">
-
-    <!-- Header Section -->
     <header class="flex flex-col md:flex-row md:items-center justify-between gap-6">
       <div>
         <h1 class="text-2xl font-bold text-slate-900 flex items-center gap-2">
@@ -371,34 +574,31 @@ onMounted(async () => {
         </h1>
         <p class="text-slate-400 text-xs mt-1.5 font-medium flex items-center">
           <svg class="w-3 h-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
-          방금 전 업데이트
+          실시간 대시보드
         </p>
       </div>
 
       <div class="flex gap-3 overflow-x-auto pb-1">
         <div v-for="(stat, idx) in stats" :key="idx" class="flex items-center gap-3 bg-white px-5 py-3 rounded-xl shadow-sm border border-slate-100 min-w-[160px]">
           <div class="w-10 h-10 rounded-full flex items-center justify-center text-lg" :class="stat.color">
-             <svg v-if="stat.icon === 'calendar'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
-             <svg v-if="stat.icon === 'briefcase'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
-             <svg v-if="stat.icon === 'user-add'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" /></svg>
+            <svg v-if="stat.icon === 'calendar'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+            <svg v-else-if="stat.icon === 'briefcase'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>
+            <svg v-else-if="stat.icon === 'users'" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-1a4 4 0 00-5.356-3.773M9 20H4v-1a4 4 0 015.356-3.773M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" /></svg>
+            <svg v-else class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 12h14M5 16h10" /></svg>
           </div>
           <div>
             <p class="text-xs text-slate-400 font-bold mb-0.5">{{ stat.label }}</p>
-            <p class="text-xl font-bold text-slate-800">{{ stat.value }}<span class="text-sm font-normal text-slate-400 ml-1">개</span></p>
+            <p class="text-xl font-bold text-slate-800">{{ stat.value }}<span class="text-sm font-normal text-slate-400 ml-1">{{ stat.unit }}</span></p>
           </div>
         </div>
       </div>
     </header>
 
-    <!-- Main Content Grid -->
-    <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-
-      <!-- Left Column: My Schedule -->
-      <div class="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm flex flex-col h-[600px]">
-        <!-- Calendar Header -->
+    <div class="grid grid-cols-1 xl:grid-cols-[minmax(0,1.08fr)_minmax(0,1fr)] gap-6 items-start">
+      <div class="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm flex flex-col h-[544px]">
         <div class="flex justify-between items-center mb-6">
           <div>
-            <h2 class="text-lg font-bold text-slate-800">내 일정</h2>
+            <h2 class="text-lg font-bold text-slate-800">오늘 일정</h2>
             <p class="text-2xl font-bold text-slate-900 mt-1">{{ currentYearMonth }}</p>
           </div>
           <div class="flex items-center gap-2">
@@ -414,7 +614,6 @@ onMounted(async () => {
           </div>
         </div>
 
-        <!-- Weekly Calendar Strip -->
         <div class="grid grid-cols-7 text-center mb-6 border-b border-slate-100 pb-6">
           <div v-for="(day, idx) in currentWeek" :key="idx" class="flex flex-col items-center gap-2 cursor-pointer group" @click="selectDate(day.dateObj)">
             <span class="text-xs font-bold text-slate-400 group-hover:text-slate-600 transition-colors">{{ day.dayName }}</span>
@@ -430,119 +629,209 @@ onMounted(async () => {
           </div>
         </div>
 
-        <!-- Schedule List for Selected Date -->
-        <div class="flex-1 flex flex-col">
+        <div class="flex-1 flex flex-col min-h-0">
           <div class="flex justify-between items-center mb-4">
             <span class="text-sm font-bold text-slate-500">{{ selectedDateDisplay }}</span>
             <span class="text-xs font-medium text-slate-400">{{ selectedSchedules.length }}개의 일정</span>
           </div>
 
           <div class="flex-1 overflow-y-auto custom-scrollbar space-y-3 pr-2">
-            <div v-if="selectedSchedules.length === 0" class="h-full flex flex-col items-center justify-center text-slate-300 min-h-[200px]">
-               <svg class="w-12 h-12 mb-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
-               <p class="text-sm font-medium">등록된 일정이 없습니다.</p>
+            <div v-if="schedulesLoading" class="h-full flex flex-col items-center justify-center text-slate-300 min-h-[200px]">
+              <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-600 mb-3"></div>
+              <p class="text-sm font-medium text-slate-400">일정을 불러오는 중입니다.</p>
+            </div>
+
+            <div v-else-if="selectedSchedules.length === 0" class="h-full flex flex-col items-center justify-center text-slate-300 min-h-[200px]">
+              <svg class="w-12 h-12 mb-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+              <p class="text-sm font-medium">선택한 날짜에 일정이 없습니다.</p>
             </div>
 
             <div v-for="schedule in selectedSchedules" :key="schedule.id"
                  @click="openScheduleDetail(schedule)"
                  class="group bg-white border border-slate-200 rounded-xl p-4 hover:border-brand-300 hover:shadow-md transition-all cursor-pointer flex items-center gap-4">
               <div class="w-1.5 h-10 rounded-full bg-brand-200 group-hover:bg-brand-500 transition-colors"></div>
-              <div class="flex-1">
-                <div class="flex justify-between items-start">
-                   <h4 class="text-sm font-bold text-slate-800 group-hover:text-brand-700">{{ schedule.title }}</h4>
-                   <span class="text-xs font-bold text-slate-500 bg-slate-100 px-1.5 py-0.5 rounded">{{ schedule.time }}</span>
+              <div class="flex-1 min-w-0">
+                <div class="flex justify-between items-start gap-3">
+                  <h4 class="text-sm font-bold text-slate-800 group-hover:text-brand-700 truncate">{{ schedule.title }}</h4>
+                  <span class="text-xs font-bold text-slate-500 bg-slate-100 px-1.5 py-0.5 rounded shrink-0">{{ schedule.time }}</span>
                 </div>
-                <p class="text-xs text-slate-500 mt-1">{{ schedule.position }} <span v-if="schedule.candidate" class="text-slate-300 mx-1">|</span> {{ schedule.candidate }}</p>
+                <p class="text-xs text-slate-500 mt-1 truncate">{{ formatScheduleSummary(schedule) }}</p>
               </div>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- Right Column -->
-      <div class="space-y-6 flex flex-col h-[600px]">
-
-        <!-- Announcements -->
-        <div class="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm flex-1 flex flex-col">
-          <div class="flex justify-between items-center mb-6">
+      <div class="space-y-6">
+        <div class="bg-white border border-slate-200 rounded-2xl p-5 shadow-sm h-[220px] flex flex-col">
+          <div class="flex justify-between items-center mb-5">
             <h2 class="text-lg font-bold text-slate-800 flex items-center gap-2">
-              사내 공지사항
+              공지사항
               <div class="flex items-center gap-2 text-sm text-slate-400 font-medium">
-
-                <button
-                    @click="prevPage"
-                    :disabled="currentPage === 1"
-                    class="px-1 hover:text-slate-600 disabled:opacity-30"
-                >
-                  &lt;
-                </button>
-
-                <span>
-    {{ currentPage }} / {{ totalPages }}
-  </span>
-
-                <button
-                    @click="nextPage"
-                    :disabled="currentPage === totalPages"
-                    class="px-1 hover:text-slate-600 disabled:opacity-30"
-                >
-                  &gt;
-                </button>
-
+                <button @click="prevPage" :disabled="currentPage === 1" class="px-1 hover:text-slate-600 disabled:opacity-30">&lt;</button>
+                <span>{{ currentPage }} / {{ totalPages }}</span>
+                <button @click="nextPage" :disabled="currentPage === totalPages" class="px-1 hover:text-slate-600 disabled:opacity-30">&gt;</button>
               </div>
             </h2>
-            <div class="flex items-center gap-2">
-              <button
-                  @click="openCreateAnnouncement"
-                  class="px-4 py-2 bg-slate-900 hover:bg-slate-800 text-white text-xs font-bold rounded-lg"
-              >
-                공지사항 만들기
-              </button>
-
-            </div>
+            <button
+              v-if="isHrMember"
+              @click="openCreateAnnouncement"
+              class="px-4 py-2 bg-slate-900 hover:bg-slate-800 text-white text-xs font-bold rounded-lg"
+            >
+              공지사항 만들기
+            </button>
           </div>
 
-          <div class="flex-1 overflow-y-auto">
-             <ul class="space-y-1">
-               <li
-                   v-for="item in pagedAnnouncements"
-                   :key="item.id"
-                   @click="openAnnouncementDetail(item.id)"
-                   class="flex justify-between items-center p-3 hover:bg-slate-50 rounded-xl cursor-pointer"
-               >                  <div class="flex items-center gap-3">
-                    <span class="text-sm font-bold text-slate-700 group-hover:text-brand-700 transition-colors">{{ item.title }}</span>
-                    <span v-if="item.tag" class="px-2 py-0.5 rounded bg-brand-100 text-brand-600 text-[10px] font-bold">{{ item.tag }}</span>
-                  </div>
-                  <span class="text-xs text-slate-400 font-mono">{{ item.date }}</span>
-               </li>
-             </ul>
+          <div class="flex-1 overflow-y-auto custom-scrollbar">
+            <ul v-if="pagedAnnouncements.length" class="space-y-1">
+              <li
+                v-for="item in pagedAnnouncements"
+                :key="item.id"
+                @click="openAnnouncementDetail(item.id)"
+                class="flex justify-between items-center p-3 hover:bg-slate-50 rounded-xl cursor-pointer"
+              >
+                <div class="flex items-center gap-3 min-w-0">
+                  <span class="text-sm font-bold text-slate-700 truncate">{{ item.title }}</span>
+                  <span v-if="item.tag" class="px-2 py-0.5 rounded bg-brand-100 text-brand-600 text-[10px] font-bold">{{ item.tag }}</span>
+                </div>
+                <span class="text-xs text-slate-400 font-mono shrink-0">{{ item.date }}</span>
+              </li>
+            </ul>
+
+            <div v-else class="h-full flex items-center justify-center text-sm text-slate-400">
+              등록된 공지사항이 없습니다.
+            </div>
           </div>
         </div>
 
+        <div class="bg-white border border-slate-200 rounded-2xl p-5 shadow-sm h-[300px] flex flex-col">
+          <div class="flex items-center justify-between mb-5">
+            <div>
+              <h2 class="text-lg font-bold text-slate-800">{{ isHrMember ? '이번 주 면접 예정' : '다가오는 일정' }}</h2>
+              <p class="text-xs text-slate-400 mt-1">
+                {{ isHrMember ? '이번 주에 예정된 면접을 빠르게 확인할 수 있어요.' : '오늘 이후 예정된 일정을 빠르게 확인할 수 있어요.' }}
+              </p>
+            </div>
+            <button
+              v-if="isHrMember"
+              @click="goToRecruitmentHome"
+              class="px-3 py-1.5 bg-brand-50 text-brand-700 border border-brand-200 rounded-lg text-xs font-bold hover:bg-brand-100 transition-colors"
+            >
+              채용 홈 이동
+            </button>
+          </div>
+
+          <div class="flex-1 overflow-y-auto custom-scrollbar pr-1">
+            <div v-if="isHrMember">
+              <div v-if="weeklyInterviewItems.length" class="space-y-3">
+                <article
+                  v-for="item in weeklyInterviewItems"
+                  :key="item.id"
+                  @click="openInterviewDetail(item)"
+                  class="rounded-xl border border-slate-200 px-4 py-3 bg-white cursor-pointer hover:border-brand-300 hover:shadow-sm transition-all"
+                >
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0">
+                      <p class="text-sm font-bold text-slate-800 truncate">{{ item.title }}</p>
+                      <p class="text-xs text-slate-500 mt-1">{{ formatMonthDayLabel(item.date) }} · {{ item.time }}</p>
+                      <p class="text-xs text-slate-500 mt-1 truncate">{{ item.applicantName || item.interviewerName || '면접 정보 없음' }}</p>
+                    </div>
+                    <span class="px-2 py-1 rounded-md bg-brand-50 text-brand-700 text-[11px] font-bold shrink-0">면접</span>
+                  </div>
+                </article>
+              </div>
+
+              <div v-else class="h-full flex flex-col items-center justify-center text-slate-300 min-h-[120px]">
+                <svg class="w-12 h-12 mb-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+                <p class="text-sm font-medium">이번 주 예정된 면접이 없습니다.</p>
+              </div>
+            </div>
+
+            <div v-else>
+              <div v-if="upcomingSchedules.length" class="space-y-3">
+                <article
+                  v-for="schedule in upcomingSchedules"
+                  :key="schedule.id"
+                  @click="openScheduleDetail(schedule)"
+                  class="rounded-xl border border-slate-200 px-4 py-3 bg-white cursor-pointer hover:border-brand-300 hover:shadow-sm transition-all"
+                >
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0">
+                      <p class="text-sm font-bold text-slate-800 truncate">{{ schedule.title }}</p>
+                      <p class="text-xs text-slate-500 mt-1">{{ formatMonthDayLabel(schedule.date) }} · {{ schedule.time }}</p>
+                      <p class="text-xs text-slate-500 mt-1 truncate">{{ formatScheduleSummary(schedule) }}</p>
+                    </div>
+                    <span class="px-2 py-1 rounded-md bg-slate-100 text-slate-600 text-[11px] font-bold shrink-0">{{ schedule.type || '일정' }}</span>
+                  </div>
+                </article>
+              </div>
+
+              <div v-else class="h-full flex flex-col items-center justify-center text-slate-300 min-h-[120px]">
+                <svg class="w-12 h-12 mb-3 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+                <p class="text-sm font-medium">다가오는 일정이 없습니다.</p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
+
+    <transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="translate-y-4 opacity-0"
+      enter-to-class="translate-y-0 opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="translate-y-0 opacity-100"
+      leave-to-class="translate-y-4 opacity-0"
+    >
+      <div
+        v-if="showDashboardChat"
+        class="fixed bottom-24 right-6 z-40 w-[420px] max-w-[calc(100vw-32px)]"
+      >
+        <DashboardChatPanel
+          :show-close-button="true"
+          @close="closeDashboardChat"
+        />
+      </div>
+    </transition>
+
+    <button
+      type="button"
+      class="fixed bottom-6 right-6 z-40 inline-flex items-center gap-3 rounded-full bg-slate-900 px-5 py-3 text-sm font-bold text-white shadow-xl shadow-slate-900/20 transition hover:bg-slate-800"
+      @click="toggleDashboardChat"
+    >
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4z" />
+      </svg>
+      <span>{{ showDashboardChat ? '익명 라운지 닫기' : '익명 라운지' }}</span>
+    </button>
 
     <ScheduleDetailModal
       :isOpen="isDetailModalOpen"
       :event="modalEvent || {}"
       @close="isDetailModalOpen = false"
     />
-  </div>
 
-  <AnnouncementModal
+    <InterviewDetailModal
+      :show="showInterviewDetailModal"
+      :event="selectedInterview || {}"
+      @close="showInterviewDetailModal = false"
+    />
+
+    <AnnouncementModal
       :show="showAnnouncementModal"
       :mode="announcementMode"
       :selected-id="selectedAnnouncementId"
       :announcements="announcements"
-      :can-manage="memberType === 'HR'"
+      :can-manage="isHrMember"
       @close="closeAnnouncement"
       @forbidden="showAnnouncementForbiddenModal"
       @create="handleSaveAnnouncement"
       @update="handleUpdateAnnouncement"
       @remove="handleRemoveAnnouncement"
-  />
+    />
 
-  <ConfirmModal
+    <ConfirmModal
       :show="feedbackModal.show"
       :type="feedbackModal.type"
       :title="feedbackModal.title"
@@ -551,8 +840,8 @@ onMounted(async () => {
       :showCancel="false"
       @confirm="feedbackModal.show = false"
       @cancel="feedbackModal.show = false"
-  />
-
+    />
+  </div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
## 💡 개요
대시보드에서 하드코딩된 데이터를 제거하고 실제 일정 및 면접 데이터를 기준으로 화면이 렌더링되도록 프론트를 정리하였으며 인사담당자와 일반 사용자/면접관의 대시보드 구성을 분리해 역할에 맞는 일정 정보를 보여주도록 개선함.
더불어 워크스페이스 공용 익명 라운지를 플로팅 채팅 UI로 추가해,  실시간 소통이 가능하도록 컴포넌트를 추가함.

## 🔗 관련 이슈
Closes #185

## 📝 작업 상세 내용
- [x] 대시보드의 오늘 일정, 다가오는 일정, 이번 주 면접을 실제 데이터 기준으로 렌더링하도록 하드코딩 제거
- [x] HR과 일반 사용자/면접관의 대시보드 레이아웃을 분리하고 공지사항/일정 카드 배치 정리
- [x] 익명 라운지 플로팅 버튼 및 채팅 패널 UI를 추가하고 SSE 기반 실시간 메시지 반영 연동

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 대시보드에 익명 채팅 패널 추가
  * 공지사항 관리 및 페이지 네이션 기능 추가
  * 면접 일정 및 주간 면접 일정 표시 기능 개선
  * 실시간 메시지 및 업데이트 스트림 지원

* **개선 사항**
  * 대시보드 UI 및 데이터 표시 방식 재구성
  * API 기반 동적 콘텐츠 로딩 적용
  * 오류 처리 및 로딩 상태 표시 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->